### PR TITLE
Bump the pv-site-datamodel dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ pytest
 pytest-cov
 python-dotenv
 pandas
-pvsite_datamodel
+pvsite-datamodel==0.1.25
 sqlalchemy
 testcontainers

--- a/src/fake.py
+++ b/src/fake.py
@@ -32,8 +32,6 @@ async def make_fake_site() -> PVSiteMetadata:
         latitude=50,
         longitude=0,
         installed_capacity_kw=1,
-        created_utc=datetime.now(timezone.utc),
-        updated_utc=datetime.now(timezone.utc),
     )
     pv_site_list = PVSites(
         site_list=[pv_site],

--- a/src/main.py
+++ b/src/main.py
@@ -94,7 +94,6 @@ async def get_sites(
                 longitude=site.longitude,
                 installed_capacity_kw=site.capacity_kw,
                 created_utc=site.created_utc,
-                updated_utc=site.updated_utc,
             )
         )
 
@@ -125,7 +124,7 @@ async def post_pv_actual(
 
         generations.append(
             {
-                "start_datetime_utc": pv_actual_value.datetime_utc,
+                "start_utc": pv_actual_value.datetime_utc,
                 "power_kw": pv_actual_value.actual_generation_kw,
                 "site_uuid": site_uuid,
             }
@@ -135,7 +134,7 @@ async def post_pv_actual(
 
     logger.debug(f"Adding {len(generation_values_df)} generation values")
 
-    _ = insert_generation_values(session=session, generation_values_df=generation_values_df)
+    insert_generation_values(session, generation_values_df)
     session.commit()
 
 
@@ -217,8 +216,8 @@ async def get_pv_actual(site_uuid: str, session: Session = Depends(get_session))
     for generation_sql in generations_sql:
         generations.append(
             PVActualValue(
-                datetime_utc=generation_sql.datetime_interval.start_utc,
-                actual_generation_kw=generation_sql.power_kw,
+                datetime_utc=generation_sql.start_utc,
+                actual_generation_kw=generation_sql.generation_power_kw,
             )
         )
     return MultiplePVActual(pv_actual_values=generations, site_uuid=site_uuid)
@@ -264,8 +263,8 @@ async def get_pv_forecast(site_uuid: str, session: Session = Depends(get_session
     for latest_forecast_value in latest_forecast_values:
         forecast_values.append(
             SiteForecastValues(
-                target_datetime_utc=latest_forecast_value.datetime_interval.start_utc,
-                expected_generation_kw=latest_forecast_value.forecast_generation_kw,
+                target_datetime_utc=latest_forecast_value.start_utc,
+                expected_generation_kw=latest_forecast_value.forecast_power_kw,
             )
         )
 

--- a/src/pydantic_models.py
+++ b/src/pydantic_models.py
@@ -39,8 +39,6 @@ class PVSiteMetadata(BaseModel):
     latitude: float = Field(..., description="The site's latitude", ge=-90, le=90)
     longitude: float = Field(..., description="The site's longitude", ge=-180, le=180)
     installed_capacity_kw: float = Field(..., description="The site's capacity in kw", ge=0)
-    created_utc: datetime = Field(..., description="Datetime the site was entered into the system.")
-    updated_utc: datetime = Field(..., description="Datetime of latest site information update.")
 
 
 # post_pv_actual

--- a/tests/test_sites.py
+++ b/tests/test_sites.py
@@ -50,7 +50,6 @@ def test_put_site_fake(fake):
         longitude=0,
         installed_capacity_kw=1,
         created_utc=datetime.now(timezone.utc).isoformat(),
-        updated_utc=datetime.now(timezone.utc).isoformat(),
     )
 
     pv_site_dict = json.loads(pv_site.json())
@@ -76,7 +75,6 @@ def test_put_site(db_session, client_sql):
         longitude=0,
         installed_capacity_kw=1,
         created_utc=datetime.now(timezone.utc).isoformat(),
-        updated_utc=datetime.now(timezone.utc).isoformat(),
     )
 
     pv_site_dict = json.loads(pv_site.json())
@@ -108,7 +106,6 @@ def test_put_site(db_session, client_sql):
 #         longitude=0,
 #         installed_capacity_kw=1,
 #         created_utc=datetime.now(timezone.utc).isoformat(),
-#         updated_utc=datetime.now(timezone.utc).isoformat(),
 #     )
 #
 #     pv_site_dict = json.loads(pv_site.json())


### PR DESCRIPTION
This updates to the recent DB schema updates in `pv-site-datamodel`.

Still TODO
- [x] Make sure the tests will pass when we bump the version of `pv-site-datamodels`
- [x] Merge https://github.com/openclimatefix/pv-site-datamodel/pull/50
- [x] Bump its version in here (pin it in `requirements.txt`)
- [x] Make sure the tests pass