### PR TITLE
Remove the `>=0` constraint for PV forecasts.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,16 @@
 SRC=pv_site_api tests
 
-.PHONY: lint
 lint:
 	poetry run ruff $(SRC)
 	poetry run black --check $(SRC)
 	poetry run isort --check $(SRC)
 
-.PHONY: format
 format:
 	poetry run ruff --fix $(SRC)
 	poetry run black $(SRC)
 	poetry run isort $(SRC)
+
+test:
+	poetry run pytest tests
+
+.PHONY: lint format test

--- a/pv_site_api/main.py
+++ b/pv_site_api/main.py
@@ -108,9 +108,6 @@ def get_sites(
 
     pv_sites = []
     for site in sites:
-        print(site.client)
-        print(site.client.client_name)
-
         pv_sites.append(
             PVSiteMetadata(
                 site_uuid=str(site.site_uuid),

--- a/pv_site_api/pydantic_models.py
+++ b/pv_site_api/pydantic_models.py
@@ -67,7 +67,7 @@ class SiteForecastValues(BaseModel):
 
     # forecast_value_uuid: str = Field(..., description="ID for this specific forecast value")
     target_datetime_utc: datetime = Field(..., description="Target time for forecast")
-    expected_generation_kw: float = Field(..., description="Expected generation in kw", ge=0)
+    expected_generation_kw: float = Field(..., description="Expected generation in kw")
 
 
 # get_forecast

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,31 +56,35 @@ def db_session(engine):
 
 
 @pytest.fixture()
-def sites(db_session):
+def clients(db_session):
+    """Make fake client sql"""
+    clients = [ClientSQL(client_name=f"test_client_{i}") for i in range(2)]
+    db_session.add_all(clients)
+    db_session.commit()
+    return clients
+
+
+@pytest.fixture()
+def sites(db_session, clients):
     """Create some fake sites"""
     sites = []
-    for i in range(0, 4):
-        client = ClientSQL(
-            client_name=f"testclient_{i}",
-        )
+    num_sites = 3
+    for i, client in enumerate(clients):
+        for j in range(num_sites):
+            site = SiteSQL(
+                client_uuid=client.client_uuid,
+                client_site_id=j,
+                client_site_name=f"site_{j}",
+                latitude=51,
+                longitude=3,
+                capacity_kw=4,
+                ml_id=i * num_sites + j,
+            )
 
-        db_session.add(client)
-        db_session.commit()
+            sites.append(site)
 
-        site = SiteSQL(
-            client_uuid=client.client_uuid,
-            client_site_id=i,
-            client_site_name=f"sites_i{i+1000}",
-            latitude=51,
-            longitude=3,
-            capacity_kw=4,
-            ml_id=i,
-        )
-
-        db_session.add(site)
-        db_session.commit()
-
-        sites.append(site)
+    db_session.add_all(sites)
+    db_session.commit()
 
     return sites
 
@@ -115,14 +119,6 @@ def fake():
     yield
 
     os.environ["FAKE"] = "0"
-
-
-@pytest.fixture()
-def client_sql(db_session):
-    """Make fake client sql"""
-    client = ClientSQL(client_name="test_client")
-    db_session.add(client)
-    db_session.commit()
 
 
 @pytest.fixture()

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -39,7 +39,7 @@ def test_get_forecast_many_sites(db_session, client, forecast_values, sites):
 
     forecasts = [Forecast(**x) for x in resp.json()]
 
-    assert len(forecasts) == 4
+    assert len(forecasts) == len(sites)
     # We have 10 forecasts with 11 values each.
     # We should get 11 values for the latest forecast, and 9 values (all but the most recent)
     # for the first prediction for each (other) forecast.

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -43,7 +43,7 @@ def test_pv_actual_many_sites(client, sites, generations):
     assert resp.status_code == 200
 
     pv_actuals = [MultiplePVActual(**x) for x in resp.json()]
-    assert len(pv_actuals) == 4
+    assert len(pv_actuals) == len(sites)
 
 
 def test_post_fake_pv_actual(client, fake):

--- a/tests/test_sites.py
+++ b/tests/test_sites.py
@@ -47,7 +47,7 @@ def test_put_site_fake(client, fake):
     assert response.status_code == 200, response.text
 
 
-def test_put_site(db_session, client, client_sql):
+def test_put_site(db_session, client, clients):
     # make site object
     pv_site = PVSiteMetadata(
         site_uuid=str(uuid4()),


### PR DESCRIPTION
_Best reviewed one commit at a time_

The first commits are small fixes here and there that I made while fixing this. The last commit fixes #56 .

I ended up not adding any warnings for simplicity, since it's not really an issue in the end.
In practice we have a few very small values (like `-0.001`) that will probably look like `0` in the front end anyway.
Also it would probably make more sense to clip or warn about values in the model and/or in the front end directly.