### PR TITLE
hide duplicate routes

### DIFF
--- a/pv_site_api/main.py
+++ b/pv_site_api/main.py
@@ -230,7 +230,7 @@ def get_pv_actual(site_uuid: str, session: Session = Depends(get_session)):
     return (get_pv_actual_many_sites(site_uuid, session))[0]
 
 
-@app.get("/sites/pv_actual", response_model=list[MultiplePVActual])
+@app.get("/sites/pv_actual", response_model=list[MultiplePVActual], include_in_schema=False)
 def get_pv_actual_many_sites(
     site_uuids: str,
     session: Session = Depends(get_session),
@@ -279,7 +279,7 @@ def get_pv_forecast(site_uuid: str, session: Session = Depends(get_session)):
     return forecasts[0]
 
 
-@app.get("/sites/pv_forecast")
+@app.get("/sites/pv_forecast", include_in_schema=False)
 def get_pv_forecast_many_sites(
     site_uuids: str,
     session: Session = Depends(get_session),


### PR DESCRIPTION
# Pull Request

## Description

hide duplicated routes

This will remove
- sites/pv_actual
- sites/pv_forecast
from swagger

![Screenshot 2023-03-27 at 10 32 12](https://user-images.githubusercontent.com/34686298/227902434-45bba235-3e8b-4535-87cd-d4fa26a25c8f.png)



Fixes #

## How Has This Been Tested?

Normall CI tests,

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
