### PR TITLE
Make site_uuid field on PVSiteMetadata model optional

### DIFF
--- a/pv_site_api/main.py
+++ b/pv_site_api/main.py
@@ -197,7 +197,6 @@ def post_site_info(site_info: PVSiteMetadata, session: Session = Depends(get_ses
     assert client is not None
 
     site = SiteSQL(
-        site_uuid=site_info.site_uuid,
         client_uuid=client.client_uuid,
         client_site_id=site_info.client_site_id,
         client_site_name=site_info.client_site_name,

--- a/pv_site_api/pydantic_models.py
+++ b/pv_site_api/pydantic_models.py
@@ -21,7 +21,7 @@ class PVSiteAPIStatus(BaseModel):
 class PVSiteMetadata(BaseModel):
     """Site metadata"""
 
-    site_uuid: str = Field(..., description="Unique internal ID for site.")
+    site_uuid: Optional[str] = Field(..., description="Unique internal ID for site.")
     client_name: str = Field(..., description="Unique name for user providing the site data.")
     client_site_id: str = Field(..., description="The site ID as given by the providing user.")
     client_site_name: str = Field(

--- a/pv_site_api/pydantic_models.py
+++ b/pv_site_api/pydantic_models.py
@@ -21,7 +21,7 @@ class PVSiteAPIStatus(BaseModel):
 class PVSiteMetadata(BaseModel):
     """Site metadata"""
 
-    site_uuid: Optional[str] = Field(..., description="Unique internal ID for site.")
+    site_uuid: Optional[str] = Field(None, description="Unique internal ID for site.")
     client_name: str = Field(..., description="Unique name for user providing the site data.")
     client_site_id: str = Field(..., description="The site ID as given by the providing user.")
     client_site_name: str = Field(

--- a/tests/test_sites.py
+++ b/tests/test_sites.py
@@ -25,7 +25,6 @@ def test_get_site_list(client, sites):
 
 def test_put_site_fake(client, fake):
     pv_site = PVSiteMetadata(
-        site_uuid="ffff-ffff",
         client_name="client_name_1",
         client_site_id="the site id used by the user",
         client_site_name="the site name",
@@ -49,6 +48,7 @@ def test_put_site_fake(client, fake):
 def test_put_site(db_session, client, clients):
     # make site object
     pv_site = PVSiteMetadata(
+        site_uuid="ffff-ffff",
         client_name="test_client",
         client_site_id=1,
         client_site_name="the site name",

--- a/tests/test_sites.py
+++ b/tests/test_sites.py
@@ -1,7 +1,6 @@
 """ Test for main app """
 import json
 from datetime import datetime, timezone
-from uuid import uuid4
 
 from pvsite_datamodel.sqlmodels import SiteSQL
 
@@ -50,7 +49,6 @@ def test_put_site_fake(client, fake):
 def test_put_site(db_session, client, clients):
     # make site object
     pv_site = PVSiteMetadata(
-        site_uuid=str(uuid4()),
         client_name="test_client",
         client_site_id=1,
         client_site_name="the site name",

--- a/tests/test_sites.py
+++ b/tests/test_sites.py
@@ -2,6 +2,8 @@
 import json
 from datetime import datetime, timezone
 
+from pvsite_datamodel.sqlmodels import SiteSQL
+
 from pv_site_api.pydantic_models import PVSiteMetadata, PVSites
 
 
@@ -64,6 +66,9 @@ def test_put_site(db_session, client, clients):
 
     response = client.post("/sites", json=pv_site_dict)
     assert response.status_code == 200, response.text
+
+    sites = db_session.query(SiteSQL).all()
+    assert len(sites) == 1
 
 
 # Comment this out, until we have security on this

--- a/tests/test_sites.py
+++ b/tests/test_sites.py
@@ -2,8 +2,6 @@
 import json
 from datetime import datetime, timezone
 
-from pvsite_datamodel.sqlmodels import SiteSQL
-
 from pv_site_api.pydantic_models import PVSiteMetadata, PVSites
 
 
@@ -48,7 +46,6 @@ def test_put_site_fake(client, fake):
 def test_put_site(db_session, client, clients):
     # make site object
     pv_site = PVSiteMetadata(
-        site_uuid="ffff-ffff",
         client_name="test_client",
         client_site_id=1,
         client_site_name="the site name",
@@ -67,10 +64,6 @@ def test_put_site(db_session, client, clients):
 
     response = client.post("/sites", json=pv_site_dict)
     assert response.status_code == 200, response.text
-
-    sites = db_session.query(SiteSQL).all()
-    assert len(sites) == 1
-    assert str(sites[0].site_uuid) == str(pv_site.site_uuid)
 
 
 # Comment this out, until we have security on this

--- a/tests/test_sites.py
+++ b/tests/test_sites.py
@@ -69,6 +69,7 @@ def test_put_site(db_session, client, clients):
 
     sites = db_session.query(SiteSQL).all()
     assert len(sites) == 1
+    assert sites[0].site_uuid is not None
 
 
 # Comment this out, until we have security on this


### PR DESCRIPTION
# Pull Request

## Description

Makes the `site_uuid` field in the `PVSiteMetadata` model optional to support automatic uuid generation by SQLAlchemy. I've also changed the site post endpoint to now not supply a site_uuid (previously from request data).

The reason I made the type optional inside `PVSiteMetadata` instead of removing is because the model is used in other endpoints which do have a valid `site_uuid`.

Fixes #62

## How Has This Been Tested?

Tested locally via accessing the endpoints. I've changed tests to now try both supplying and not supplying a site uuid when creating a site.

- [x] Yes (on GitHub actions)

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
