### PR TITLE
Add WHERE statement on query for past forecasts

### DIFF
--- a/pv_site_api/_db_helpers.py
+++ b/pv_site_api/_db_helpers.py
@@ -40,6 +40,7 @@ def _get_forecasts_for_horizon(
         .where(ForecastSQL.site_uuid.in_(site_uuids))
         # Also filtering on `timestamp_utc` makes the query faster.
         .where(ForecastSQL.timestamp_utc >= start_utc - dt.timedelta(minutes=horizon_minutes))
+        .where(ForecastSQL.timestamp_utc < end_utc)
         .where(ForecastValueSQL.horizon_minutes == horizon_minutes)
         .where(ForecastValueSQL.start_utc >= start_utc)
         .where(ForecastValueSQL.start_utc < end_utc)


### PR DESCRIPTION
This doesn't change the result but speeds up the query in general.

I did some tests using this snippet:
```python
import datetime as dt
import time

from pvsite_datamodel.sqlmodels import SiteSQL
from sqlalchemy import create_engine, select
from sqlalchemy.orm import sessionmaker

from pv_site_api._db_helpers import _get_forecasts_for_horizon

engine = create_engine("postgresql://main@localhost:9997/pvsitedevelopment")

Session = sessionmaker(engine)

with Session() as session:
    stmt = select(SiteSQL.site_uuid)

    site_uuids = session.scalars(stmt).all()

    t0 = time.time()
    data = _get_forecasts_for_horizon(
        session,
        site_uuids=site_uuids,
        start_utc=dt.datetime(2023, 3, 29),
        end_utc=dt.datetime(2023, 3, 30),
        horizon_minutes=0,
    )
    t1 = time.time()

    print(len(data))
    print(t1 - t0)
```

and it seems to make some difference, although sometimes it's hard to tell if it's a question of index being in memory or not. The new query typically takes 5-6 seconds when run on all the sites for 24h (like in the snippet).