### PR TITLE
Uniformize check to FAKE and fix related test

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 90%
+    patch:
+      default:
+        target: 90%

--- a/pv_site_api/main.py
+++ b/pv_site_api/main.py
@@ -70,6 +70,10 @@ def traces_sampler(sampling_context):
         return 0.05
 
 
+def is_fake():
+    return int(os.environ.get("FAKE", 0))
+
+
 sentry_sdk.init(
     dsn=os.getenv("SENTRY_DSN"),
     environment=os.getenv("ENVIRONMENT", "local"),
@@ -112,7 +116,7 @@ def get_sites(
     ### This route returns a list of the user's PV Sites with metadata for each site.
     """
 
-    if int(os.environ["FAKE"]):
+    if is_fake():
         return make_fake_site()
 
     sites = get_all_sites(session=session)
@@ -142,7 +146,7 @@ def post_pv_actual(
     Currently this route does not return anything.
     """
 
-    if int(os.environ["FAKE"]):
+    if is_fake():
         print(f"Got {pv_actual.dict()} for site {site_uuid}")
         print("Not doing anything with it (yet!)")
         return
@@ -174,7 +178,7 @@ def post_pv_actual(
 #
 #     """
 #
-#     if int(os.environ["FAKE"]):
+#     if is_fake():
 #         print(f"Successfully updated {site_info.dict()} for site {site_info.client_site_name}")
 #         print("Not doing anything with it (yet!)")
 #         return
@@ -189,7 +193,7 @@ def post_site_info(site_info: PVSiteMetadata, session: Session = Depends(get_ses
 
     """
 
-    if int(os.environ["FAKE"]):
+    if is_fake():
         print(f"Successfully added {site_info.dict()} for site {site_info.client_site_name}")
         print("Not doing anything with it (yet!)")
         return
@@ -241,7 +245,7 @@ def get_pv_actual_many_sites(
     """
     site_uuids_list = site_uuids.split(",")
 
-    if int(os.environ["FAKE"]):
+    if is_fake():
         return [make_fake_pv_generation(site_uuid) for site_uuid in site_uuids_list]
 
     start_utc = get_yesterday_midnight()
@@ -264,7 +268,7 @@ def get_pv_forecast(site_uuid: str, session: Session = Depends(get_session)):
     You can currently input any number for **site_uuid** (ex. 567),
     and the route returns a sample forecast.
     """
-    if int(os.environ.get("FAKE", 0)):
+    if is_fake():
         return make_fake_forecast(fake_site_uuid)
 
     site_exists = does_site_exist(session, site_uuid)
@@ -291,7 +295,7 @@ def get_pv_forecast_many_sites(
 
     logger.info(f"Getting forecasts for {site_uuids}")
 
-    if int(os.environ.get("FAKE", 0)):
+    if is_fake():
         return [make_fake_forecast(fake_site_uuid)]
 
     start_utc = get_yesterday_midnight()
@@ -311,7 +315,7 @@ def get_pv_estimate_clearsky(site_uuid: str, session: Session = Depends(get_sess
     """
     ### Gets a estimate of AC production under a clear sky
     """
-    if int(os.environ["FAKE"]):
+    if is_fake():
         fake_sites = make_fake_site()
         site = fake_sites.site_list[0]
     else:
@@ -370,7 +374,7 @@ def get_status(session: Session = Depends(get_session)):
     make sure things are running smoothly.
     """
 
-    if os.environ["FAKE"]:
+    if is_fake():
         return make_fake_status()
 
     status = get_latest_status(session=session)

--- a/pv_site_api/session.py
+++ b/pv_site_api/session.py
@@ -7,7 +7,7 @@ from pvsite_datamodel.connection import DatabaseConnection
 
 def get_session():
     """Get database settion"""
-    if int(os.environ["FAKE"]):
+    if int(os.environ.get("FAKE", 0)):
         yield None
     else:
         connection = DatabaseConnection(url=os.getenv("DB_URL", "not_set"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 import os
 from datetime import datetime, timedelta
 
+import freezegun
 import pytest
 from fastapi.testclient import TestClient
 from pvsite_datamodel.sqlmodels import (
@@ -19,6 +20,13 @@ from testcontainers.postgres import PostgresContainer
 
 from pv_site_api.main import app
 from pv_site_api.session import get_session
+
+
+@pytest.fixture
+def _now(autouse=True):
+    """Hard-code the time for all tests to make the tests less flaky."""
+    with freezegun.freeze_time(2020, 1, 1):
+        return datetime.utcnow()
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ from pvsite_datamodel.sqlmodels import (
     ForecastValueSQL,
     GenerationSQL,
     SiteSQL,
+    StatusSQL,
 )
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
@@ -112,13 +113,26 @@ def generations(db_session, sites):
 
 
 @pytest.fixture()
-def fake():
+def statuses(db_session):
+    all_statuses = [
+        StatusSQL(
+            status=f"my_status {i}",
+            message=f"my message {i}",
+        )
+        for i in range(2)
+    ]
+    db_session.add_all(all_statuses)
+    db_session.commit()
+
+    return all_statuses
+
+
+@pytest.fixture()
+def fake(monkeypatch):
     """Set up ENV VAR FAKE to 1"""
-    os.environ["FAKE"] = "1"
-
-    yield
-
-    os.environ["FAKE"] = "0"
+    with monkeypatch.context() as m:
+        m.setenv("FAKE", "1")
+        yield
 
 
 @pytest.fixture()

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -12,10 +12,10 @@ def test_get_fake_status(client, fake):
     assert returned_status.message == "The API is up and running"
 
 
-def test_get_status(client):
+def test_get_status(client, statuses):
     response = client.get("/api_status")
     assert response.status_code == 200
 
     returned_status = PVSiteAPIStatus(**response.json())
-    assert returned_status.status == "ok"
-    assert returned_status.message == "The API is up and running"
+    assert returned_status.status == "my_status 1"
+    assert returned_status.message == "my message 1"


### PR DESCRIPTION
Our checks to the environment variables were different and error prone (one test was silently broken). It's also annoying to pass `FAKE=0` when wanting to start the API, as this feels like a sane default.

In this PR I make them uniform and make it optional to pass `FAKE=0`.

-------

Some tests were breaking depending on the time at which they ran so I hard-coded the times in all the tests using `freezegun` (see the last commit of the PR).