### PR TITLE
Add enode link URL endpoint

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -591,25 +591,25 @@ test = ["Cython (>=0.29.24,<0.30.0)"]
 
 [[package]]
 name = "httpx"
-version = "0.23.3"
+version = "0.24.0"
 description = "The next generation HTTP client."
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "httpx-0.23.3-py3-none-any.whl", hash = "sha256:a211fcce9b1254ea24f0cd6af9869b3d29aba40154e947d2a07bb499b3e310d6"},
-    {file = "httpx-0.23.3.tar.gz", hash = "sha256:9818458eb565bb54898ccb9b8b251a28785dd4a55afbc23d0eb410754fe7d0f9"},
+    {file = "httpx-0.24.0-py3-none-any.whl", hash = "sha256:447556b50c1921c351ea54b4fe79d91b724ed2b027462ab9a329465d147d5a4e"},
+    {file = "httpx-0.24.0.tar.gz", hash = "sha256:507d676fc3e26110d41df7d35ebd8b3b8585052450f4097401c9be59d928c63e"},
 ]
 
 [package.dependencies]
 certifi = "*"
-httpcore = ">=0.15.0,<0.17.0"
-rfc3986 = {version = ">=1.3,<2", extras = ["idna2008"]}
+httpcore = ">=0.15.0,<0.18.0"
+idna = "*"
 sniffio = "*"
 
 [package.extras]
 brotli = ["brotli", "brotlicffi"]
-cli = ["click (>=8.0.0,<9.0.0)", "pygments (>=2.0.0,<3.0.0)", "rich (>=10,<13)"]
+cli = ["click (>=8.0.0,<9.0.0)", "pygments (>=2.0.0,<3.0.0)", "rich (>=10,<14)"]
 http2 = ["h2 (>=3,<5)"]
 socks = ["socksio (>=1.0.0,<2.0.0)"]
 
@@ -1198,6 +1198,25 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
 
 [[package]]
+name = "pytest-httpx"
+version = "0.22.0"
+description = "Send responses to httpx."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pytest_httpx-0.22.0-py3-none-any.whl", hash = "sha256:cefb7dcf66a4cb0601b0de05e576cca423b6081f3245e7912a4d84c58fa3eae8"},
+    {file = "pytest_httpx-0.22.0.tar.gz", hash = "sha256:3a82797f3a9a14d51e8c6b7fa97524b68b847ee801109c062e696b4744f4431c"},
+]
+
+[package.dependencies]
+httpx = ">=0.24.0,<0.25.0"
+pytest = ">=6.0,<8.0"
+
+[package.extras]
+testing = ["pytest-asyncio (>=0.20.0,<0.21.0)", "pytest-cov (>=4.0.0,<5.0.0)"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
@@ -1334,24 +1353,6 @@ urllib3 = ">=1.21.1,<1.27"
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
-
-[[package]]
-name = "rfc3986"
-version = "1.5.0"
-description = "Validating URI References per RFC 3986"
-category = "main"
-optional = false
-python-versions = "*"
-files = [
-    {file = "rfc3986-1.5.0-py2.py3-none-any.whl", hash = "sha256:a86d6e1f5b1dc238b218b012df0aa79409667bb209e58da56d0b94704e712a97"},
-    {file = "rfc3986-1.5.0.tar.gz", hash = "sha256:270aaf10d87d0d4e095063c65bf3ddbc6ee3d0b226328ce21e036f946e421835"},
-]
-
-[package.dependencies]
-idna = {version = "*", optional = true, markers = "extra == \"idna2008\""}
-
-[package.extras]
-idna2008 = ["idna"]
 
 [[package]]
 name = "ruff"
@@ -1989,4 +1990,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "7d40ec6ff03dfcba06a62d9876081b3814157dad550e82e336448b646310f05c"
+content-hash = "c97b76c8280335ca70d6e6bb755328db3b0c1c6f10e8abca9e43bf5709e32a77"

--- a/pv_site_api/fake.py
+++ b/pv_site_api/fake.py
@@ -88,6 +88,6 @@ def make_fake_status() -> PVSiteAPIStatus:
     return pv_api_status
 
 
-def make_fake_enode_link() -> str:
+def make_fake_enode_link_url() -> str:
     """Make fake Enode link URL"""
     return "https://enode.com"

--- a/pv_site_api/fake.py
+++ b/pv_site_api/fake.py
@@ -86,3 +86,8 @@ def make_fake_status() -> PVSiteAPIStatus:
         message="The API is up and running",
     )
     return pv_api_status
+
+
+def make_fake_enode_link() -> str:
+    """Make fake Enode link URL"""
+    return "https://enode.com"

--- a/pv_site_api/main.py
+++ b/pv_site_api/main.py
@@ -9,7 +9,7 @@ from dotenv import load_dotenv
 from fastapi import Depends, FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.utils import get_openapi
-from fastapi.responses import FileResponse, JSONResponse
+from fastapi.responses import FileResponse, JSONResponse, RedirectResponse
 from pvlib import irradiance, location, pvsystem
 from pvsite_datamodel.read.site import get_all_sites, get_site_by_uuid
 from pvsite_datamodel.read.status import get_latest_status
@@ -27,7 +27,7 @@ from ._db_helpers import (
 )
 from .fake import (
     fake_site_uuid,
-    make_fake_enode_link,
+    make_fake_enode_link_url,
     make_fake_forecast,
     make_fake_pv_generation,
     make_fake_site,
@@ -357,13 +357,13 @@ def get_pv_estimate_clearsky(site_uuid: str, session: Session = Depends(get_sess
     return res
 
 
-@app.get("/enode/link")
+@app.get("/enode/link", response_class=RedirectResponse)
 def get_enode_link(redirect_uri: str, session: Session = Depends(get_session)):
     """
     ### Returns a URL from Enode that starts a user's Enode link flow.
     """
     if int(os.environ["FAKE"]):
-        return make_fake_enode_link()
+        return make_fake_enode_link_url()
 
     client = session.query(ClientSQL).first()
     assert client is not None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ psycopg2-binary = "^2.9.5"
 sqlalchemy = "^1.4.46"
 pvsite-datamodel = { git = "https://github.com/openclimatefix/pv-site-datamodel.git", branch = "enode-updates" }
 fastapi = "^0.92.0"
-httpx = "^0.23.3"
+httpx = "^0.24.0"
 sentry-sdk = "^1.16.0"
 pvlib = "^0.9.5"
 
@@ -26,6 +26,7 @@ pytest = "^7.2.1"
 pytest-cov = "^4.0.0"
 testcontainers-postgres = "^0.0.1rc1"
 ipython = "^8.11.0"
+pytest-httpx = "^0.22.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,6 +66,7 @@ def clients(db_session):
 
 @pytest.fixture
 def non_mocked_hosts() -> list:
+    """Prevent TestClient fixture from being mocked"""
     return ["testserver"]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,6 +64,11 @@ def clients(db_session):
     return clients
 
 
+@pytest.fixture
+def non_mocked_hosts() -> list:
+    return ["testserver"]
+
+
 @pytest.fixture()
 def sites(db_session, clients):
     """Create some fake sites"""

--- a/tests/test_enode.py
+++ b/tests/test_enode.py
@@ -1,0 +1,20 @@
+def test_get_enode_link_fake(client, fake):
+    params = {"redirect_uri": "https://example.org"}
+    response = client.get(f"/enode/link", params=params)
+    assert response.status_code == 200
+    assert len(response.json()) > 0
+
+
+def test_get_enode_link(client, clients, httpx_mock):
+    test_redirect_uri = "https://example.com"
+
+    httpx_mock.add_response(
+        url=f"https://enode-api.production.enode.io/users/{clients[0].client_uuid}/link",
+        json={"linkUrl": test_redirect_uri},
+    )
+
+    params = {"redirect_uri": "https://example.org"}
+    response = client.get("/enode/link", params=params)
+
+    assert response.status_code == 200
+    assert response.json() == test_redirect_uri

--- a/tests/test_enode.py
+++ b/tests/test_enode.py
@@ -1,8 +1,9 @@
 def test_get_enode_link_fake(client, fake):
     params = {"redirect_uri": "https://example.org"}
-    response = client.get("/enode/link", params=params)
-    assert response.status_code == 200
-    assert len(response.json()) > 0
+    response = client.get("/enode/link", params=params, follow_redirects=False)
+
+    assert response.status_code == 307
+    assert len(response.headers["location"]) > 0
 
 
 def test_get_enode_link(client, clients, httpx_mock):
@@ -14,7 +15,11 @@ def test_get_enode_link(client, clients, httpx_mock):
     )
 
     params = {"redirect_uri": "https://example.org"}
-    response = client.get("/enode/link", params=params)
+    response = client.get(
+        "/enode/link",
+        params=params,
+        follow_redirects=False,
+    )
 
-    assert response.status_code == 200
-    assert response.json() == test_enode_link_uri
+    assert response.status_code == 307
+    assert response.headers["location"] == test_enode_link_uri

--- a/tests/test_enode.py
+++ b/tests/test_enode.py
@@ -1,6 +1,6 @@
 def test_get_enode_link_fake(client, fake):
     params = {"redirect_uri": "https://example.org"}
-    response = client.get(f"/enode/link", params=params)
+    response = client.get("/enode/link", params=params)
     assert response.status_code == 200
     assert len(response.json()) > 0
 

--- a/tests/test_enode.py
+++ b/tests/test_enode.py
@@ -6,15 +6,15 @@ def test_get_enode_link_fake(client, fake):
 
 
 def test_get_enode_link(client, clients, httpx_mock):
-    test_redirect_uri = "https://example.com"
+    test_enode_link_uri = "https://example.com"
 
     httpx_mock.add_response(
         url=f"https://enode-api.production.enode.io/users/{clients[0].client_uuid}/link",
-        json={"linkUrl": test_redirect_uri},
+        json={"linkUrl": test_enode_link_uri},
     )
 
     params = {"redirect_uri": "https://example.org"}
     response = client.get("/enode/link", params=params)
 
     assert response.status_code == 200
-    assert response.json() == test_redirect_uri
+    assert response.json() == test_enode_link_uri


### PR DESCRIPTION
# Pull Request

## Description

Adds an endpoint for getting a valid Enode link URL for a user.

Fixes #72

**Need to use env vars for Enode URLs, but coming in another PR**

## How Has This Been Tested?

Adds a test for both fake and mock Enode requests.

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
