### PR TITLE
Fix single site actual endpoint and fix response content error in dev

### DIFF
--- a/pv_site_api/main.py
+++ b/pv_site_api/main.py
@@ -252,7 +252,20 @@ def get_pv_actual(
     To test the route, you can input any number for the site_uuid (ex. 567)
     to generate a list of datetimes and actual kw generation for that site.
     """
-    return (get_pv_actual_many_sites(site_uuids=site_uuid, session=session))[0]
+    if is_fake():
+        return make_fake_pv_generation(fake_site_uuid)
+
+    site_exists = does_site_exist(session, site_uuid)
+
+    if not site_exists:
+        raise HTTPException(status_code=404)
+
+    actuals = get_pv_actual_many_sites(site_uuids=site_uuid, session=session)
+
+    if len(actuals) == 0:
+        return JSONResponse(status_code=204, content="no data")
+
+    return actuals[0]
 
 
 @app.get("/sites/pv_actual", response_model=list[MultiplePVActual])

--- a/pv_site_api/main.py
+++ b/pv_site_api/main.py
@@ -197,7 +197,7 @@ def post_pv_actual(
 #     raise Exception(NotImplemented)
 
 
-@app.post("/sites")
+@app.post("/sites", status_code=201)
 def post_site_info(
     site_info: PVSiteMetadata,
     session: Session = Depends(get_session),
@@ -236,6 +236,8 @@ def post_site_info(
     # add site
     session.add(site)
     session.commit()
+
+    return site_to_pydantic(site)
 
 
 # get_pv_actual: the client can read pv data from the past

--- a/pv_site_api/main.py
+++ b/pv_site_api/main.py
@@ -8,7 +8,7 @@ from dotenv import load_dotenv
 from fastapi import Depends, FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.utils import get_openapi
-from fastapi.responses import FileResponse, JSONResponse
+from fastapi.responses import FileResponse, JSONResponse, Response
 from pvlib import irradiance, location, pvsystem
 from pvsite_datamodel.read.site import get_all_sites
 from pvsite_datamodel.read.status import get_latest_status
@@ -263,7 +263,7 @@ def get_pv_actual(
     actuals = get_pv_actual_many_sites(site_uuids=site_uuid, session=session)
 
     if len(actuals) == 0:
-        return JSONResponse(status_code=204, content="no data")
+        return Response(status_code=204)
 
     return actuals[0]
 
@@ -318,7 +318,7 @@ def get_pv_forecast(
     forecasts = get_pv_forecast_many_sites(site_uuids=site_uuid, session=session)
 
     if len(forecasts) == 0:
-        return JSONResponse(status_code=204, content="no data")
+        return Response(status_code=204)
 
     return forecasts[0]
 

--- a/pv_site_api/main.py
+++ b/pv_site_api/main.py
@@ -8,7 +8,7 @@ from dotenv import load_dotenv
 from fastapi import Depends, FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.utils import get_openapi
-from fastapi.responses import FileResponse, JSONResponse, Response
+from fastapi.responses import FileResponse, Response
 from pvlib import irradiance, location, pvsystem
 from pvsite_datamodel.read.site import get_all_sites
 from pvsite_datamodel.read.status import get_latest_status

--- a/tests/test_sites.py
+++ b/tests/test_sites.py
@@ -43,7 +43,7 @@ def test_put_site_fake(client, fake):
     pv_site_dict = json.loads(pv_site.json())
 
     response = client.post("/sites", json=pv_site_dict)
-    assert response.status_code == 200, response.text
+    assert response.status_code == 201, response.text
 
 
 def test_put_site(db_session, client, clients):
@@ -67,7 +67,7 @@ def test_put_site(db_session, client, clients):
     pv_site_dict = json.loads(pv_site.json())
 
     response = client.post("/sites", json=pv_site_dict)
-    assert response.status_code == 200, response.text
+    assert response.status_code == 201, response.text
 
     sites = db_session.query(SiteSQL).all()
     assert len(sites) == 1


### PR DESCRIPTION
# Pull Request

## Description

This PR fixes a bug with the single site actuals endpoints, where an array index at 0 is out of bounds since a site has no actual data. This also fixes a bug with the way no content responses were being sent previously, where some content was attached. This yielded an error in development at least, since the 204 was supposed to have no content at all.

This PR also expands on the site create endpoint by returning the created site's information, including the generated ID, which is necessary for the frontend.

**Breaking**: Changed POST site success response code **200** &rarr; **201**.

Something to note is that the `ml_id` is not autoincrementing correctly, and thus cannot be left unset here, but cannot be set to `1` since it must be unique. I think autoincrementing does make the most sense though, as mentioned in [this comment](https://github.com/openclimatefix/pv-site-datamodel/issues/27#issuecomment-1562696988). I'm not entirely sure why it's not autoincrementing, but it might have to do with this [stackoverflow comment](https://stackoverflow.com/a/67506153) and Postgres.

Also incrementing the `client_site_id` automatically would be useful.

## How Has This Been Tested?

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
