### PR TITLE
Issue/add capacity mw back in

### DIFF
--- a/pv_site_api/main.py
+++ b/pv_site_api/main.py
@@ -252,7 +252,7 @@ def post_site_info(
         longitude=site_info.longitude,
         inverter_capacity_kw=site_info.inverter_capacity_kw,
         module_capacity_kw=site_info.module_capacity_kw,
-        capacity_kw=site_info.module_capacity_kw, # fill remove this one in the future
+        capacity_kw=site_info.module_capacity_kw,  # fill remove this one in the future
         ml_id=max_ml_id + 1,
     )
 

--- a/pv_site_api/main.py
+++ b/pv_site_api/main.py
@@ -252,6 +252,7 @@ def post_site_info(
         longitude=site_info.longitude,
         inverter_capacity_kw=site_info.inverter_capacity_kw,
         module_capacity_kw=site_info.module_capacity_kw,
+        capacity_kw=site_info.module_capacity_kw, # fill remove this one in the future
         ml_id=max_ml_id + 1,
     )
 


### PR DESCRIPTION
# Pull Request

## Description

add `capacity_kw` back in when adding a site. This makes the forecast work properly


## How Has This Been Tested?

CI tests
add capacity kw back in on a failing forecast

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
