### PR TITLE
Issue/compact

### DIFF
--- a/pv_site_api/_db_helpers.py
+++ b/pv_site_api/_db_helpers.py
@@ -29,8 +29,8 @@ from .pydantic_models import (
     Forecast,
     ManyForecastCompact,
     MultiplePVActual,
+    MultipleSitePVActualCompact,
     PVActualValue,
-    PVActualValueBySite,
     PVSiteMetadata,
 )
 
@@ -142,7 +142,7 @@ def get_forecasts_by_sites(
 
 def get_generation_by_sites(
     session: Session, site_uuids: list[str], start_utc: dt.datetime, compact: bool = False
-) -> Union[list[MultiplePVActual], list[PVActualValueBySite]]:
+) -> Union[list[MultiplePVActual], MultipleSitePVActualCompact]:
     """Get the generation since yesterday (midnight) for a list of sites."""
     logger.info(f"Getting generation for {len(site_uuids)} sites")
     rows = get_pv_generation_by_sites(

--- a/pv_site_api/_db_helpers.py
+++ b/pv_site_api/_db_helpers.py
@@ -19,13 +19,19 @@ from pvsite_datamodel.read.user import get_user_by_email
 from pvsite_datamodel.sqlmodels import ForecastSQL, ForecastValueSQL, SiteSQL
 from sqlalchemy.orm import Session, aliased
 
+from .convert import (
+    forecast_rows_to_pydantic,
+    forecast_rows_to_pydantic_compact,
+    generation_rows_to_pydantic,
+    generation_rows_to_pydantic_compact,
+)
 from .pydantic_models import (
     Forecast,
     MultiplePVActual,
+    MultiplePVActualBySite,
+    OneDatetimeManyForecasts,
     PVActualValue,
     PVSiteMetadata,
-    SiteForecastValues,
-    MultiplePVActualBySite, PVActualValueBySite
 )
 
 logger = structlog.stdlib.get_logger()
@@ -94,56 +100,13 @@ def _get_latest_forecast_by_sites(
     return query.all()
 
 
-def _forecast_rows_to_pydantic(rows: list[Row]) -> list[Forecast]:
-    """Make a list of `(ForecastSQL, ForecastValueSQL)` rows into our pydantic `Forecast`
-    objects.
-
-    Note that we remove duplicate ForecastValueSQL when found.
-    """
-    # Per-site metadata.
-    data: dict[str, dict[str, Any]] = defaultdict(dict)
-    # Per-site forecast values.
-    values: dict[str, list[SiteForecastValues]] = defaultdict(list)
-    # Per-site *set* of ForecastValueSQL.forecast_value_uuid to be able to filter out duplicates.
-    # This is useful in particular because our latest forecast and past forecasts will overlap in
-    # the middle.
-    fv_uuids: dict[str, set[uuid.UUID]] = defaultdict(set)
-
-    for row in rows:
-        site_uuid = str(row.ForecastSQL.site_uuid)
-
-        if site_uuid not in data:
-            data[site_uuid]["site_uuid"] = site_uuid
-            data[site_uuid]["forecast_uuid"] = str(row.ForecastSQL.forecast_uuid)
-            data[site_uuid]["forecast_creation_datetime"] = row.ForecastSQL.timestamp_utc
-            data[site_uuid]["forecast_version"] = row.ForecastSQL.forecast_version
-
-        fv_uuid = row.ForecastValueSQL.forecast_value_uuid
-
-        if fv_uuid not in fv_uuids[site_uuid]:
-            values[site_uuid].append(
-                SiteForecastValues(
-                    target_datetime_utc=row.ForecastValueSQL.start_utc,
-                    expected_generation_kw=row.ForecastValueSQL.forecast_power_kw,
-                )
-            )
-            fv_uuids[site_uuid].add(fv_uuid)
-
-    return [
-        Forecast(
-            forecast_values=values[site_uuid],
-            **data[site_uuid],
-        )
-        for site_uuid in data.keys()
-    ]
-
-
 def get_forecasts_by_sites(
     session: Session,
     site_uuids: list[str],
     start_utc: dt.datetime,
     horizon_minutes: int,
-) -> list[Forecast]:
+    compact: bool = False,
+) -> Union[list[Forecast], list[OneDatetimeManyForecasts]]:
     """Combination of the latest forecast and the past forecasts, for given sites.
 
     This is what we show in the UI.
@@ -168,7 +131,10 @@ def get_forecasts_by_sites(
     logger.debug("Found %s future forecasts", len(rows_future))
 
     logger.debug("Formatting forecasts to pydantic objects")
-    forecasts = _forecast_rows_to_pydantic(rows_past + rows_future)
+    if compact:
+        forecasts = forecast_rows_to_pydantic_compact(rows_past + rows_future)
+    else:
+        forecasts = forecast_rows_to_pydantic(rows_past + rows_future)
     logger.debug("Formatting forecasts to pydantic objects: done")
 
     return forecasts
@@ -176,7 +142,7 @@ def get_forecasts_by_sites(
 
 def get_generation_by_sites(
     session: Session, site_uuids: list[str], start_utc: dt.datetime, compact: bool = False
-) -> list[MultiplePVActual]:
+) -> Union[list[MultiplePVActual], MultiplePVActualBySite]:
     """Get the generation since yesterday (midnight) for a list of sites."""
     logger.info(f"Getting generation for {len(site_uuids)} sites")
     rows = get_pv_generation_by_sites(
@@ -188,42 +154,9 @@ def get_generation_by_sites(
 
     # TODO can we speed this up?
     if not compact:
-        logger.info("Formatting generation 1")
-        for row in rows:
-            site_uuid = str(row.site_uuid)
-            pv_actual_values_per_site[site_uuid].append(
-                PVActualValue(
-                    datetime_utc=row.start_utc,
-                    actual_generation_kw=row.generation_power_kw,
-                )
-            )
-
-        logger.info("Formatting generation 2")
-        multiple_pv_actuals = [
-            MultiplePVActual(site_uuid=site_uuid, pv_actual_values=pv_actual_values)
-            for site_uuid, pv_actual_values in pv_actual_values_per_site.items()
-        ]
-
-        logger.debug(f"Getting generation for {len(site_uuids)} sites: done")
-        return multiple_pv_actuals
+        return generation_rows_to_pydantic(pv_actual_values_per_site, rows, site_uuids)
     else:
-        pv_actual_values_per_site = {}
-        for row in rows:
-            site_uuid = str(row.site_uuid)
-            start_utc = row.start_utc
-            if start_utc in pv_actual_values_per_site:
-                pv_actual_values_per_site[start_utc][site_uuid] = row.generation_power_kw
-            else:
-                pv_actual_values_per_site[start_utc] = {site_uuid: row.generation_power_kw}
-
-        multiple_pv_actuals = []
-        for start_utc, pv_actual_values in pv_actual_values_per_site.items():
-            multiple_pv_actuals.append(
-                PVActualValueBySite(datetime_utc=start_utc, generation_kw_by_location=pv_actual_values)
-            )
-
-        return MultiplePVActualBySite(pv_actual_values=multiple_pv_actuals)
-
+        return generation_rows_to_pydantic_compact(rows)
 
 
 def get_sites_by_uuids(session: Session, site_uuids: list[str]) -> list[PVSiteMetadata]:

--- a/pv_site_api/_db_helpers.py
+++ b/pv_site_api/_db_helpers.py
@@ -28,9 +28,9 @@ from .convert import (
 from .pydantic_models import (
     Forecast,
     MultiplePVActual,
-    MultiplePVActualBySite,
     OneDatetimeManyForecasts,
     PVActualValue,
+    PVActualValueBySite,
     PVSiteMetadata,
 )
 
@@ -142,7 +142,7 @@ def get_forecasts_by_sites(
 
 def get_generation_by_sites(
     session: Session, site_uuids: list[str], start_utc: dt.datetime, compact: bool = False
-) -> Union[list[MultiplePVActual], MultiplePVActualBySite]:
+) -> Union[list[MultiplePVActual], list[PVActualValueBySite]]:
     """Get the generation since yesterday (midnight) for a list of sites."""
     logger.info(f"Getting generation for {len(site_uuids)} sites")
     rows = get_pv_generation_by_sites(

--- a/pv_site_api/_db_helpers.py
+++ b/pv_site_api/_db_helpers.py
@@ -27,8 +27,8 @@ from .convert import (
 )
 from .pydantic_models import (
     Forecast,
+    ManyForecastCompact,
     MultiplePVActual,
-    OneDatetimeManyForecasts,
     PVActualValue,
     PVActualValueBySite,
     PVSiteMetadata,
@@ -106,7 +106,7 @@ def get_forecasts_by_sites(
     start_utc: dt.datetime,
     horizon_minutes: int,
     compact: bool = False,
-) -> Union[list[Forecast], list[OneDatetimeManyForecasts]]:
+) -> Union[list[Forecast], ManyForecastCompact]:
     """Combination of the latest forecast and the past forecasts, for given sites.
 
     This is what we show in the UI.

--- a/pv_site_api/convert.py
+++ b/pv_site_api/convert.py
@@ -1,0 +1,135 @@
+"""Functions to convert sql rows to pydantic models."""
+import datetime as dt
+import uuid
+from collections import defaultdict
+from typing import Any, List
+
+import numpy as np
+import structlog
+
+from pv_site_api.pydantic_models import (
+    Forecast,
+    MultiplePVActual,
+    MultiplePVActualBySite,
+    OneDatetimeManyForecasts,
+    PVActualValue,
+    PVActualValueBySite,
+    SiteForecastValues,
+)
+
+logger = structlog.stdlib.get_logger()
+
+# Sqlalchemy rows are tricky to type: we use this to make the code more readable.
+Row = Any
+
+
+def forecast_rows_to_pydantic_compact(rows: list[Row]) -> List[OneDatetimeManyForecasts]:
+    """
+    Convert Forecast rows to a ManyDatetimesManyForecasts object.
+
+    This produces a compact version of the forecast data.
+    """
+    fv_datetimes: dict[dt.datetime, dict[str, float]] = {}
+
+    for row in rows:
+        site_uuid = str(row.ForecastSQL.site_uuid)
+
+        start_utc = row.ForecastValueSQL.start_utc
+        forecast_power_kw = np.round(row.ForecastValueSQL.forecast_power_kw, 2)
+
+        if start_utc not in fv_datetimes:
+            fv_datetimes[start_utc] = {site_uuid: forecast_power_kw}
+        else:
+            fv_datetimes[start_utc][site_uuid] = forecast_power_kw
+
+    forecasts = []
+    for k, v in fv_datetimes.items():
+        forecasts.append(OneDatetimeManyForecasts(datetime_utc=k, forecast_per_site=v))
+
+    return forecasts
+
+
+def forecast_rows_to_pydantic(rows: list[Row]) -> list[Forecast]:
+    """Make a list of `(ForecastSQL, ForecastValueSQL)` rows into our pydantic `Forecast`
+    objects.
+
+    Note that we remove duplicate ForecastValueSQL when found.
+    """
+    # Per-site metadata.
+    data: dict[str, dict[str, Any]] = defaultdict(dict)
+    # Per-site forecast values.
+    values: dict[str, list[SiteForecastValues]] = defaultdict(list)
+    # Per-site *set* of ForecastValueSQL.forecast_value_uuid to be able to filter out duplicates.
+    # This is useful in particular because our latest forecast and past forecasts will overlap in
+    # the middle.
+    fv_uuids: dict[str, set[uuid.UUID]] = defaultdict(set)
+
+    for row in rows:
+        site_uuid = str(row.ForecastSQL.site_uuid)
+
+        if site_uuid not in data:
+            data[site_uuid]["site_uuid"] = site_uuid
+            data[site_uuid]["forecast_uuid"] = str(row.ForecastSQL.forecast_uuid)
+            data[site_uuid]["forecast_creation_datetime"] = row.ForecastSQL.timestamp_utc
+            data[site_uuid]["forecast_version"] = row.ForecastSQL.forecast_version
+
+        fv_uuid = row.ForecastValueSQL.forecast_value_uuid
+
+        if fv_uuid not in fv_uuids[site_uuid]:
+            values[site_uuid].append(
+                SiteForecastValues(
+                    target_datetime_utc=row.ForecastValueSQL.start_utc,
+                    expected_generation_kw=row.ForecastValueSQL.forecast_power_kw,
+                )
+            )
+            fv_uuids[site_uuid].add(fv_uuid)
+
+    return [
+        Forecast(
+            forecast_values=values[site_uuid],
+            **data[site_uuid],
+        )
+        for site_uuid in data.keys()
+    ]
+
+
+def generation_rows_to_pydantic(pv_actual_values_per_site, rows, site_uuids):
+    """Convert generation rows to a MultiplePVActual object."""
+    logger.info("Formatting generation 1")
+    for row in rows:
+        site_uuid = str(row.site_uuid)
+        pv_actual_values_per_site[site_uuid].append(
+            PVActualValue(
+                datetime_utc=row.start_utc,
+                actual_generation_kw=row.generation_power_kw,
+            )
+        )
+
+    logger.info("Formatting generation 2")
+    multiple_pv_actuals = [
+        MultiplePVActual(site_uuid=site_uuid, pv_actual_values=pv_actual_values)
+        for site_uuid, pv_actual_values in pv_actual_values_per_site.items()
+    ]
+    logger.debug(f"Getting generation for {len(site_uuids)} sites: done")
+    return multiple_pv_actuals
+
+
+def generation_rows_to_pydantic_compact(rows):
+    """Convert generation rows to a MultiplePVActualBySite object.
+
+    This produces a compact version of the generation data."""
+    pv_actual_values_per_site = {}
+    for row in rows:
+        site_uuid = str(row.site_uuid)
+        start_utc = row.start_utc
+        if start_utc in pv_actual_values_per_site:
+            pv_actual_values_per_site[start_utc][site_uuid] = row.generation_power_kw
+        else:
+            pv_actual_values_per_site[start_utc] = {site_uuid: row.generation_power_kw}
+
+    multiple_pv_actuals = []
+    for start_utc, pv_actual_values in pv_actual_values_per_site.items():
+        multiple_pv_actuals.append(
+            PVActualValueBySite(datetime_utc=start_utc, generation_kw_by_location=pv_actual_values)
+        )
+    return MultiplePVActualBySite(pv_actual_values=multiple_pv_actuals)

--- a/pv_site_api/convert.py
+++ b/pv_site_api/convert.py
@@ -136,7 +136,7 @@ def generation_rows_to_pydantic(pv_actual_values_per_site, rows, site_uuids):
     return multiple_pv_actuals
 
 
-def generation_rows_to_pydantic_compact(rows):
+def generation_rows_to_pydantic_compact(rows) -> MultipleSitePVActualCompact:
     """Convert generation rows to a MultiplePVActualBySite object.
 
     This produces a compact version of the generation data."""

--- a/pv_site_api/convert.py
+++ b/pv_site_api/convert.py
@@ -10,7 +10,6 @@ import structlog
 from pv_site_api.pydantic_models import (
     Forecast,
     MultiplePVActual,
-    MultiplePVActualBySite,
     OneDatetimeManyForecasts,
     PVActualValue,
     PVActualValueBySite,
@@ -132,4 +131,4 @@ def generation_rows_to_pydantic_compact(rows):
         multiple_pv_actuals.append(
             PVActualValueBySite(datetime_utc=start_utc, generation_kw_by_location=pv_actual_values)
         )
-    return MultiplePVActualBySite(pv_actual_values=multiple_pv_actuals)
+    return multiple_pv_actuals

--- a/pv_site_api/main.py
+++ b/pv_site_api/main.py
@@ -43,7 +43,7 @@ from .pydantic_models import (
     ClearskyEstimate,
     Forecast,
     MultiplePVActual,
-    PVActualValueBySite,
+    MultipleSitePVActualCompact,
     PVSiteAPIStatus,
     PVSiteMetadata,
     PVSites,
@@ -304,7 +304,7 @@ def get_pv_actual(
 
 
 @app.get(
-    "/sites/pv_actual", response_model=Union[list[MultiplePVActual], list[PVActualValueBySite]]
+    "/sites/pv_actual", response_model=Union[list[MultiplePVActual], MultipleSitePVActualCompact]
 )
 @cache_response
 def get_pv_actual_many_sites(

--- a/pv_site_api/main.py
+++ b/pv_site_api/main.py
@@ -43,7 +43,7 @@ from .pydantic_models import (
     ClearskyEstimate,
     Forecast,
     MultiplePVActual,
-    MultiplePVActualBySite,
+    PVActualValueBySite,
     PVSiteAPIStatus,
     PVSiteMetadata,
     PVSites,
@@ -303,7 +303,9 @@ def get_pv_actual(
     return actuals[0]
 
 
-@app.get("/sites/pv_actual", response_model=Union[list[MultiplePVActual], MultiplePVActualBySite])
+@app.get(
+    "/sites/pv_actual", response_model=Union[list[MultiplePVActual], list[PVActualValueBySite]]
+)
 @cache_response
 def get_pv_actual_many_sites(
     site_uuids: str,

--- a/pv_site_api/main.py
+++ b/pv_site_api/main.py
@@ -1,6 +1,7 @@
 """Main API Routes"""
 import os
 import time
+from typing import Union
 
 import pandas as pd
 import sentry_sdk
@@ -17,7 +18,6 @@ from pvsite_datamodel.sqlmodels import SiteSQL
 from pvsite_datamodel.write.generation import insert_generation_values
 from sqlalchemy import func
 from sqlalchemy.orm import Session
-from typing import Union
 
 import pv_site_api
 
@@ -43,10 +43,10 @@ from .pydantic_models import (
     ClearskyEstimate,
     Forecast,
     MultiplePVActual,
+    MultiplePVActualBySite,
     PVSiteAPIStatus,
     PVSiteMetadata,
     PVSites,
-    MultiplePVActualBySite,
 )
 from .redoc_theme import get_redoc_html_with_theme
 from .session import get_session
@@ -56,8 +56,6 @@ load_dotenv()
 
 logger = structlog.stdlib.get_logger()
 
-import ssl
-ssl._create_default_https_context = ssl._create_unverified_context
 
 def traces_sampler(sampling_context):
     """
@@ -325,7 +323,9 @@ def get_pv_actual_many_sites(
 
     start_utc = get_yesterday_midnight()
 
-    return get_generation_by_sites(session, site_uuids=site_uuids_list, start_utc=start_utc, compact=compact)
+    return get_generation_by_sites(
+        session, site_uuids=site_uuids_list, start_utc=start_utc, compact=compact
+    )
 
 
 # get_forecast: Client gets the forecast for their site
@@ -371,6 +371,7 @@ def get_pv_forecast_many_sites(
     site_uuids: str,
     session: Session = Depends(get_session),
     auth: dict = Depends(auth),
+    compact: bool = False,
 ):
     """
     ### Get the forecasts for multiple sites.
@@ -389,7 +390,7 @@ def get_pv_forecast_many_sites(
     logger.debug(f"Loading forecast from {start_utc}")
 
     forecasts = get_forecasts_by_sites(
-        session, site_uuids=site_uuids_list, start_utc=start_utc, horizon_minutes=0
+        session, site_uuids=site_uuids_list, start_utc=start_utc, horizon_minutes=0, compact=compact
     )
 
     return forecasts

--- a/pv_site_api/pydantic_models.py
+++ b/pv_site_api/pydantic_models.py
@@ -70,6 +70,22 @@ class MultiplePVActual(BaseModel):
     )
 
 
+class PVActualValueBySite(BaseModel):
+    """PV Actual Value list"""
+
+    datetime_utc: datetime = Field(..., description="Time of data input")
+    generation_kw_by_location: dict = Field(..., description="Actual kw generation by location "
+                                                             "e.g {sites_uuid_1: 0.2, sites_uuid_2: 0.4}")
+
+
+class MultiplePVActualBySite(BaseModel):
+    """Site data for one site"""
+
+    pv_actual_values: List[PVActualValueBySite] = Field(
+        ..., description="List of datetimes and generation"
+    )
+
+
 class SiteForecastValues(BaseModel):
     """Forecast value list"""
 

--- a/pv_site_api/pydantic_models.py
+++ b/pv_site_api/pydantic_models.py
@@ -1,7 +1,7 @@
 """Pydantic models for PV Site API"""
 # import packages
 from datetime import datetime
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from pydantic import BaseModel, Field, validator
 
@@ -74,8 +74,11 @@ class PVActualValueBySite(BaseModel):
     """PV Actual Value list"""
 
     datetime_utc: datetime = Field(..., description="Time of data input")
-    generation_kw_by_location: dict = Field(..., description="Actual kw generation by location "
-                                                             "e.g {sites_uuid_1: 0.2, sites_uuid_2: 0.4}")
+    generation_kw_by_location: dict = Field(
+        ...,
+        description="Actual kw generation by location "
+        "e.g {sites_uuid_1: 0.2, sites_uuid_2: 0.4}",
+    )
 
 
 class MultiplePVActualBySite(BaseModel):
@@ -112,6 +115,15 @@ class Forecast(BaseModel):
     forecast_version: str = Field(..., description="Forecast version")
     forecast_values: List[SiteForecastValues] = Field(
         ..., description="List of target times and generation"
+    )
+
+
+class OneDatetimeManyForecasts(BaseModel):
+    """Forecast for one datetime for many sites"""
+
+    datetime_utc: datetime = Field(..., description="Target time for forecast")
+    forecast_per_site: Dict[str, str] = Field(
+        ..., description="Dictionary of forecasts for each site "
     )
 
 

--- a/pv_site_api/pydantic_models.py
+++ b/pv_site_api/pydantic_models.py
@@ -70,6 +70,25 @@ class MultiplePVActual(BaseModel):
     )
 
 
+class MultiplePVActualCompact(BaseModel):
+    """Site data for one site"""
+
+    site_uuid: str = Field(..., description="The site id")
+    pv_actual_values: dict[int, float] = Field(
+        ..., description="List of datetimes indexes and generation"
+    )
+
+
+class MultipleSitePVActualCompact(BaseModel):
+    start_utc_idx: dict[datetime, int] = Field(
+        ...,
+        description="Dictionary of start datetimes and their index in the pv_actual_values list",
+    )
+    pv_actual_values_many_site: List[MultiplePVActualCompact] = Field(
+        ..., description="List of generation data for each site"
+    )
+
+
 class PVActualValueBySite(BaseModel):
     """PV Actual Value list"""
 
@@ -110,13 +129,28 @@ class Forecast(BaseModel):
     )
 
 
-class OneDatetimeManyForecasts(BaseModel):
+class ForecastCompact(BaseModel):
+    """PV Forecast"""
+
+    forecast_uuid: str = Field(..., description="The forecast id")
+    site_uuid: str = Field(..., description="The site id")
+    forecast_creation_datetime: datetime = Field(
+        ..., description="The time that the forecast was created."
+    )
+    forecast_version: str = Field(..., description="Forecast version")
+    forecast_values: Dict[int, float] = Field(
+        ..., description="List of target times indexes and generation"
+    )
+
+
+class ManyForecastCompact(BaseModel):
     """Forecast for one datetime for many sites"""
 
-    datetime_utc: datetime = Field(..., description="Target time for forecast")
-    forecast_per_site: Dict[str, str] = Field(
-        ..., description="Dictionary of forecasts for each site "
+    target_time_idx: dict[datetime, int] = Field(
+        ...,
+        description="Dictionary of target datetimes and their index in the forecast_values list",
     )
+    forecasts: List[ForecastCompact] = Field(..., description="Target time for forecast")
 
 
 # get_sites

--- a/pv_site_api/pydantic_models.py
+++ b/pv_site_api/pydantic_models.py
@@ -81,14 +81,6 @@ class PVActualValueBySite(BaseModel):
     )
 
 
-class MultiplePVActualBySite(BaseModel):
-    """Site data for one site"""
-
-    pv_actual_values: List[PVActualValueBySite] = Field(
-        ..., description="List of datetimes and generation"
-    )
-
-
 class SiteForecastValues(BaseModel):
     """Forecast value list"""
 

--- a/pv_site_api/pydantic_models.py
+++ b/pv_site_api/pydantic_models.py
@@ -89,17 +89,6 @@ class MultipleSitePVActualCompact(BaseModel):
     )
 
 
-class PVActualValueBySite(BaseModel):
-    """PV Actual Value list"""
-
-    datetime_utc: datetime = Field(..., description="Time of data input")
-    generation_kw_by_location: dict = Field(
-        ...,
-        description="Actual kw generation by location "
-        "e.g {sites_uuid_1: 0.2, sites_uuid_2: 0.4}",
-    )
-
-
 class SiteForecastValues(BaseModel):
     """Forecast value list"""
 

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 from freezegun import freeze_time
 from pvsite_datamodel.sqlmodels import SiteSQL
 
-from pv_site_api.pydantic_models import Forecast, OneDatetimeManyForecasts
+from pv_site_api.pydantic_models import Forecast, ManyForecastCompact
 
 
 def test_get_forecast_fake(client, fake):
@@ -114,13 +114,13 @@ def test_get_forecast_many_sites_late_forecast_one_day_compact(
         resp = client.get(f"/sites/pv_forecast?site_uuids={site_uuids_str}&compact=true")
         assert resp.status_code == 200
 
-        f = [OneDatetimeManyForecasts(**x) for x in resp.json()]
+        f = ManyForecastCompact(**resp.json())
 
     # We have 10 forecasts with 11 values each.
     # We should get 11 values for the latest forecast, and 9 values (all but the most recent)
     # for the first prediction for each (other) forecast.
-    assert len(f) == 20
-    assert len(f[0].forecast_per_site) == len(sites)
+    assert len(f.forecasts[0].forecast_values) == 20
+    assert len(f.forecasts) == len(sites)
 
 
 def test_get_forecast_no_data(db_session, client, sites):

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 
 from pvsite_datamodel.sqlmodels import GenerationSQL
 
-from pv_site_api.pydantic_models import MultiplePVActual, PVActualValue, PVActualValueBySite
+from pv_site_api.pydantic_models import MultiplePVActual, MultipleSitePVActualCompact, PVActualValue
 
 
 def test_pv_actual_fake(client, fake):
@@ -55,8 +55,8 @@ def test_pv_actual_many_sites_compact(client, sites, generations):
 
     assert resp.status_code == 200
 
-    pv_actuals = [PVActualValueBySite(**x) for x in resp.json()]
-    assert len(pv_actuals[0].generation_kw_by_location) == len(sites)
+    pv_actuals = MultipleSitePVActualCompact(**resp.json())
+    assert len(pv_actuals.pv_actual_values_many_site) == len(sites)
 
 
 def test_post_fake_pv_actual(client, fake):

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 
 from pvsite_datamodel.sqlmodels import GenerationSQL
 
-from pv_site_api.pydantic_models import MultiplePVActual, PVActualValue
+from pv_site_api.pydantic_models import MultiplePVActual, PVActualValue, PVActualValueBySite
 
 
 def test_pv_actual_fake(client, fake):
@@ -45,6 +45,18 @@ def test_pv_actual_many_sites(client, sites, generations):
 
     pv_actuals = [MultiplePVActual(**x) for x in resp.json()]
     assert len(pv_actuals) == len(sites)
+
+
+def test_pv_actual_many_sites_compact(client, sites, generations):
+    site_uuids = [str(s.site_uuid) for s in sites]
+    site_uuid_str = ",".join(site_uuids)
+
+    resp = client.get(f"/sites/pv_actual?site_uuids={site_uuid_str}&compact=true")
+
+    assert resp.status_code == 200
+
+    pv_actuals = [PVActualValueBySite(**x) for x in resp.json()]
+    assert len(pv_actuals[0].generation_kw_by_location) == len(sites)
 
 
 def test_post_fake_pv_actual(client, fake):


### PR DESCRIPTION
# Pull Request

## Description

add options for compact on forecast and generation for lots of sites

Forecasts and generations: Take about the Same time, and 1/5 the space. 
This is for 35 sites, so I imagine the saving would grow for more sites. The main thing was to extract the timestamps and create index for them. 

For the nowcasting and gsp api we swapped time and location, but this didnt work here as the location id, is a uuid, compared to a `gsp_id`

Fixes #112 

## How Has This Been Tested?

CI tests + tested locally

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
