### PR TITLE
add links for swagger UI and docs to API docs

### DIFF
--- a/pv_site_api/main.py
+++ b/pv_site_api/main.py
@@ -97,7 +97,11 @@ title = "Quartz PV Site API"
 
 folder = os.path.dirname(os.path.abspath(__file__))
 description = """
-Description of PV Site API
+The Quartz Solar PV Site API generates site-specific pv forecasts for users.
+
+This API is built with [FastAPI](https://fastapi.tiangolo.com/), offering 
+users the options to both try API routes with the [`/swagger`](/swagger) UI 
+and read documentation with the sleek Redocs layout at [`/docs`](/docs).
 """
 
 origins = os.getenv("ORIGINS", "*").split(",")
@@ -581,7 +585,7 @@ def custom_openapi():
         version=pv_site_api.__version__,
         description=description,
         contact={
-            "name": "Nowcasting by Open Climate Fix",
+            "name": "Quartz Solar by Open Climate Fix",
             "url": "https://quartz.solar",
             "email": "info@openclimatefix.org",
         },

--- a/pv_site_api/main.py
+++ b/pv_site_api/main.py
@@ -100,8 +100,9 @@ description = """
 The Quartz Solar PV Site API generates site-specific pv forecasts for users.
 
 This API is built with [FastAPI](https://fastapi.tiangolo.com/), offering 
-users the options to both try API routes with the [`/swagger`](/swagger) UI 
-and read documentation with the sleek Redocs layout at [`/docs`](/docs).
+users the options to both try API routes with the [`/swagger`](https://api-site.quartz.solar/swagger) UI 
+and read the [`/docs`](https://api-site.quartz.solar/docs) with the sleeker 
+Redocs layout. The information is the same in both places. 
 """
 
 origins = os.getenv("ORIGINS", "*").split(",")

--- a/pv_site_api/main.py
+++ b/pv_site_api/main.py
@@ -100,9 +100,10 @@ description = """
 The Quartz Solar PV Site API generates site-specific pv forecasts for users.
 
 This API is built with [FastAPI](https://fastapi.tiangolo.com/), offering 
-users the options to both try API routes with the [`/swagger`](https://api-site.quartz.solar/swagger) UI 
+users the options to both try API routes with the
+[`/swagger`](https://api-site.quartz.solar/swagger) UI
 and read the [`/docs`](https://api-site.quartz.solar/docs) with the sleeker 
-Redocs layout. The information is the same in both places. 
+Redocs layout. The information is the same in both places.
 """
 
 origins = os.getenv("ORIGINS", "*").split(",")


### PR DESCRIPTION
# Pull Request

## Description

Adds a brief description to the PV Site API docs that will better communicate to users how to test out the API.  The links I've added should just add `/docs` or `/swagger` to the page's base url. 

<img width="552" alt="Screenshot 2023-11-27 at 12 55 31" src="https://github.com/openclimatefix/pv-site-api/assets/86949265/16592588-1918-4c64-886a-4bc8a7af571c">

Fixes # issue that came up in the Full Stack Chat this morning

## How Has This Been Tested?

Ran the api locally to view the changes. 

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
