### PR TITLE
timezone aware method

### DIFF
--- a/pv_site_api/_db_helpers.py
+++ b/pv_site_api/_db_helpers.py
@@ -7,7 +7,6 @@ style.
 """
 
 import datetime as dt
-from datetime import timezone
 import uuid
 from collections import defaultdict
 from typing import Any, Optional, Union
@@ -164,7 +163,7 @@ def get_forecasts_by_sites(
 
     logger.info(f"Getting forecast for {len(site_uuids)} sites")
 
-    end_utc = dt.datetime.now(tz=timezone.utc)
+    end_utc = dt.datetime.now(tz=dt.timezone.utc)
 
     rows_past = _get_forecasts_for_horizon(
         session,

--- a/pv_site_api/_db_helpers.py
+++ b/pv_site_api/_db_helpers.py
@@ -7,6 +7,7 @@ style.
 """
 
 import datetime as dt
+from datetime import timezone
 import uuid
 from collections import defaultdict
 from typing import Any, Optional, Union
@@ -163,7 +164,7 @@ def get_forecasts_by_sites(
 
     logger.info(f"Getting forecast for {len(site_uuids)} sites")
 
-    end_utc = dt.datetime.utcnow()
+    end_utc = dt.datetime.now(tz=timezone.utc)
 
     rows_past = _get_forecasts_for_horizon(
         session,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 """ Pytest fixtures for tests """
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import freezegun
 import pytest
@@ -19,7 +19,7 @@ from pv_site_api.session import get_session
 def _now(autouse=True):
     """Hard-code the time for all tests to make the tests less flaky."""
     with freezegun.freeze_time(2020, 1, 1):
-        return datetime.utcnow()
+        return datetime.now(tz=timezone.utc)
 
 
 @pytest.fixture(scope="session")
@@ -136,7 +136,10 @@ def forecast_values(db_session, sites):
     num_forecasts = 10
     num_values_per_forecast = 11
 
-    timestamps = [datetime.utcnow() - timedelta(minutes=10 * i) for i in range(num_forecasts)]
+    timestamps = [
+        datetime.now(tz=timezone.utc) - timedelta(minutes=10 * i) 
+        for i in range(num_forecasts)
+    ]
 
     # To make things trickier we make a second forecast at the same for one of the timestamps.
     timestamps = timestamps + timestamps[-1:]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,8 +137,7 @@ def forecast_values(db_session, sites):
     num_values_per_forecast = 11
 
     timestamps = [
-        datetime.now(tz=timezone.utc) - timedelta(minutes=10 * i) 
-        for i in range(num_forecasts)
+        datetime.now(tz=timezone.utc) - timedelta(minutes=10 * i) for i in range(num_forecasts)
     ]
 
     # To make things trickier we make a second forecast at the same for one of the timestamps.

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -1,7 +1,7 @@
 """ Test for main app """
 
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from freezegun import freeze_time
 from pvsite_datamodel.pydantic_models import ForecastValueSum
@@ -63,7 +63,7 @@ def test_get_forecast_many_sites_late_forecast_one_week(db_session, client, fore
     site_uuids = [str(s.site_uuid) for s in sites]
     site_uuids_str = ",".join(site_uuids)
 
-    one_week_from_now = datetime.utcnow() + timedelta(days=7)
+    one_week_from_now = datetime.now(tz=timezone.utc) + timedelta(days=7)
     with freeze_time(one_week_from_now):
         resp = client.get(f"/sites/pv_forecast?site_uuids={site_uuids_str}")
         assert resp.status_code == 200
@@ -77,7 +77,7 @@ def test_get_forecast_many_sites_late_forecast_one_day(db_session, client, forec
     """Test the case where the forecast stop working 1 day ago"""
     site_uuids = [str(s.site_uuid) for s in sites]
     site_uuids_str = ",".join(site_uuids)
-    one_day_from_now = datetime.utcnow() + timedelta(days=1)
+    one_day_from_now = datetime.now(tz=timezone.utc) + timedelta(days=1)
 
     with freeze_time(one_day_from_now):
         resp = client.get(f"/sites/pv_forecast?site_uuids={site_uuids_str}")
@@ -109,7 +109,7 @@ def test_get_forecast_many_sites_late_forecast_one_day_compact(
     """Test the case where the forecast stop working 1 day ago"""
     site_uuids = [str(s.site_uuid) for s in sites]
     site_uuids_str = ",".join(site_uuids)
-    one_day_from_now = datetime.utcnow() + timedelta(days=1)
+    one_day_from_now = datetime.now(tz=timezone.utc) + timedelta(days=1)
 
     with freeze_time(one_day_from_now):
         resp = client.get(f"/sites/pv_forecast?site_uuids={site_uuids_str}&compact=true")
@@ -130,7 +130,7 @@ def test_get_forecast_many_sites_late_forecast_one_day_total(
     """Test the case where the forecast stop working 1 day ago"""
     site_uuids = [str(s.site_uuid) for s in sites]
     site_uuids_str = ",".join(site_uuids)
-    one_day_from_now = datetime.utcnow() + timedelta(days=1)
+    one_day_from_now = datetime.now(tz=timezone.utc) + timedelta(days=1)
 
     with freeze_time(one_day_from_now):
         resp = client.get(f"/sites/pv_forecast?site_uuids={site_uuids_str}&sum_by=total")
@@ -150,7 +150,7 @@ def test_get_forecast_many_sites_late_forecast_one_day_dno(
     """Test the case where the forecast stop working 1 day ago"""
     site_uuids = [str(s.site_uuid) for s in sites]
     site_uuids_str = ",".join(site_uuids)
-    one_day_from_now = datetime.utcnow() + timedelta(days=1)
+    one_day_from_now = datetime.now(tz=timezone.utc) + timedelta(days=1)
 
     with freeze_time(one_day_from_now):
         resp = client.get(f"/sites/pv_forecast?site_uuids={site_uuids_str}&sum_by=dno")
@@ -170,7 +170,7 @@ def test_get_forecast_many_sites_late_forecast_one_day_gsp(
     """Test the case where the forecast stop working 1 day ago"""
     site_uuids = [str(s.site_uuid) for s in sites]
     site_uuids_str = ",".join(site_uuids)
-    one_day_from_now = datetime.utcnow() + timedelta(days=1)
+    one_day_from_now = datetime.now(tz=timezone.utc) + timedelta(days=1)
 
     with freeze_time(one_day_from_now):
         resp = client.get(f"/sites/pv_forecast?site_uuids={site_uuids_str}&sum_by=gsp")

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -100,7 +100,9 @@ def test_get_forecast_many_sites_late_forecast_one_day(db_session, client, forec
     # check they are all less than one day from now
     for forecast in forecasts:
         for forecast_value in forecast.forecast_values:
-            assert forecast_value.target_datetime_utc.replace(tzinfo=timezone.utc) < one_day_from_now
+            assert forecast_value.target_datetime_utc.replace(
+                tzinfo=timezone.utc
+            ) < one_day_from_now
 
 
 def test_get_forecast_many_sites_late_forecast_one_day_compact(

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -100,7 +100,7 @@ def test_get_forecast_many_sites_late_forecast_one_day(db_session, client, forec
     # check they are all less than one day from now
     for forecast in forecasts:
         for forecast_value in forecast.forecast_values:
-            assert forecast_value.target_datetime_utc < one_day_from_now
+            assert forecast_value.target_datetime_utc.replace(tzinfo=timezone.utc) < one_day_from_now
 
 
 def test_get_forecast_many_sites_late_forecast_one_day_compact(


### PR DESCRIPTION
# Pull Request

## Description

the datetime.utcnow() method is considered deprecated in modern Python versions, and it's recommended to use the more explicit datetime.now(tz=datetime.timezone.utc) instead. The utcnow() method is still functional, but it's considered less clear and less timezone-aware than the alternative. I have thus replaced the deprecated method with the newer one

Fixes #

Replaces the deprecated method with the newer one

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have checked my code and corrected any misspellings
