### PR TITLE
Add edit_site method

### DIFF
--- a/pv_site_api/main.py
+++ b/pv_site_api/main.py
@@ -287,14 +287,15 @@ def put_site_info(
     #### Parameters
     - **site_uuid**: The site uuid, for example '8d39a579-8bed-490e-800e-1395a8eb6535'
     - **site_info**: The site informations to update.
+        You can update one or more fields at a time. For example :
+        {"orientation": 170, "tilt": 35, "module_capacity_kw": 5}
     """
 
     if is_fake():
-        print(
-            f"Successfully updated {site_info.model_dump()} for site {site_info.client_site_name}"
-        )
+        print(f"Successfully updated {site_info.model_dump()} for site {site_uuid}")
         print("Not doing anything with it (yet!)")
-        return
+        site = make_fake_site().site_list[0]
+        return site
 
     site_exists = does_site_exist(session, site_uuid)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,9 +18,9 @@ sentry-sdk = "^1.16.0"
 pvlib = "^0.9.5"
 structlog = "^22.3.0"
 pyjwt = {extras = ["crypto"], version = "^2.6.0"}
-pvsite-datamodel = "1.0.19"
 geopandas = "^0.14.2"
 psutil = "^6.0.0"
+pvsite-datamodel = "^1.0.30"
 
 [tool.poetry.group.dev.dependencies]
 isort = "^5.12.0"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,6 +3,8 @@
 import json
 from datetime import datetime, timezone
 
+from pvsite_datamodel.pydantic_models import PVSiteEditMetadata
+
 from pv_site_api import __version__
 from pv_site_api.pydantic_models import MultiplePVActual, PVActualValue, PVSiteAPIStatus
 
@@ -52,4 +54,13 @@ def test_delete_site(client, fake):
     response = client.delete("/sites/delete/fff-fff-fff")
 
     assert response.json()["message"] == "Site deleted successfully"
+    assert response.status_code == 200
+
+
+def test_put_site_info(client, fake):
+    info_to_edit = PVSiteEditMetadata(orientation=25)
+
+    obj = json.loads(info_to_edit.model_dump_json())
+
+    response = client.put("/sites/fff-fff-fff", json=obj)
     assert response.status_code == 200

--- a/tests/test_sites.py
+++ b/tests/test_sites.py
@@ -107,37 +107,35 @@ def test_put_site(db_session, client):
     assert sites[1].ml_id == 2
 
 
-# Comment this out, until we have security on this
-# def test_put_site_and_update(db_session):
-#     pv_site = PVSiteMetadata(
-#         site_uuid=str(uuid4()),
-#         client_uuid="eeee-eeee",
-#         client_site_id="the site id used by the user",
-#         client_site_name="the site name",
-#         region="the site's region",
-#         dno="the site's dno",
-#         gsp="the site's gsp",
-#         orientation=180,
-#         tilt=90,
-#         latitude=50,
-#         longitude=0,
-#         installed_capacity_kw=1,
-#         created_utc=datetime.now(timezone.utc).isoformat(),
-#     )
-#
-#     pv_site_dict = json.loads(pv_site.json())
-#
-#     response = client.post(f"sites/", json=pv_site_dict)
-#     assert response.status_code == 200, response.text
-#
-#     pv_site.orientation = 100
-#     pv_site_dict = json.loads(pv_site.json())
-#
-#     response = client.put(f"sites/{pv_site.site_uuid}", json=pv_site_dict)
-#     assert response.status_code == 200, response.text
-#
-#     sites = db_session.query(SiteSQL).all()
-#     assert len(sites) == 1
-#     assert sites[0].site_uuid == pv_site.site_uuid
-#     assert sites[0].orientation == pv_site.orientation
-#
+def test_put_site_and_update(db_session, client):
+    pv_site = PVSiteInputMetadata(
+        client_name="test_client",
+        client_site_id=1,
+        client_site_name="the site name",
+        region="the site's region",
+        dno="the site's dno",
+        gsp="the site's gsp",
+        orientation=180,
+        tilt=90,
+        latitude=50,
+        longitude=0,
+        inverter_capacity_kw=1,
+        module_capacity_kw=1.2,
+        created_utc=datetime.now(timezone.utc).isoformat(),
+    )
+
+    pv_site_dict = json.loads(pv_site.model_dump_json())
+
+    response = client.post("sites/", json=pv_site_dict)
+    assert response.status_code == 201, response.text
+
+    pv_site_put = response.json()
+    site_uuid = pv_site_put["site_uuid"]
+
+    response = client.put(f"sites/{site_uuid}", json={"orientation": 120})
+    assert response.status_code == 200, response.text
+
+    sites = db_session.query(SiteSQL).all()
+    assert len(sites) == 1
+    assert sites[0].orientation == 120
+    assert sites[0].tilt == 90


### PR DESCRIPTION
# Pull Request

## Description

This PR refers to the issue #178 : edit site 

Creation of the route and put_site_info method in main.py, that call edit_site function from pvsite_datamodel.

## How Has This Been Tested?

Creation of 2 test functions:
- test_put_site_info  in test_main.py, testing the route
- test_put_site_and_update in test_sites.py, testing that the site metadata is actually updated.

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
