### PR TITLE
update forecast_uuid to represent latest forecast

### DIFF
--- a/pv_site_api/convert.py
+++ b/pv_site_api/convert.py
@@ -99,6 +99,8 @@ def forecast_rows_to_pydantic(rows: list[Row]) -> list[Forecast]:
         # make sure we use the latest forecast_creation_datetime
         if row.ForecastSQL.timestamp_utc > data[site_uuid]["forecast_creation_datetime"]:
             data[site_uuid]["forecast_creation_datetime"] = row.ForecastSQL.timestamp_utc
+            data[site_uuid]["forecast_uuid"] = str(row.ForecastSQL.forecast_uuid)
+            data[site_uuid]["forecast_version"] = row.ForecastSQL.forecast_version
 
         fv_uuid = row.ForecastValueSQL.forecast_value_uuid
 


### PR DESCRIPTION
# Pull Request

## Description

Changing how the forecast_uuid variable is updated. To fix #183.

Now the forecast_uuid represents the latest forecast made, hence it is updated every forecast run. 