### PR TITLE
speed up forecast future

### DIFF
--- a/pv_site_api/_db_helpers.py
+++ b/pv_site_api/_db_helpers.py
@@ -19,7 +19,7 @@ from pvsite_datamodel.read.generation import get_pv_generation_by_sites
 from pvsite_datamodel.read.user import get_user_by_email
 from pvsite_datamodel.sqlmodels import ForecastSQL, ForecastValueSQL, SiteGroupSiteSQL, SiteSQL
 from sqlalchemy import func
-from sqlalchemy.orm import Session, aliased
+from sqlalchemy.orm import Session
 
 from .convert import (
     forecast_rows_sums_to_pydantic_objects,


### PR DESCRIPTION
# Pull Request

## Description

Speed up for future forecasts

When pulling 7 sites
2 datestamps: 45 seconds to <1 seconds
no datetimes filters: ~45 seconds to 1.75 seconds

for 99 sites
2 datestamps: 45 seconds to <1 seconds
no datetimes filters: ~45 seconds to 8 seconds

#206 

## How Has This Been Tested?

- [x] CI tests
- [x] ran it locally and tested above

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
