### PR TITLE
filter forecast on ml model

### DIFF
--- a/pv_site_api/_db_helpers.py
+++ b/pv_site_api/_db_helpers.py
@@ -117,7 +117,7 @@ def _get_latest_forecast_by_sites(
     sum_by: Optional[str] = None,
 ) -> list[Row]:
     """Get the latest forecast for given site uuids.
-    
+
     Here are the following steps we do
     1. Get all locations, and split between those with ML models and those without
     2. For those locations with ML models, get the latest forecast uuid where the ML model matches


### PR DESCRIPTION
# Pull Request

## Description

Before this PR, when a model is assigned to a site, it only worked for the model that was run last in the site-forecast-app. but it didnt work for all models for that site. This PR fixes this. 

Solution was to add
1. Look at all sites, and split between sites that have models assigned, and none. 
2. For sites with no models assigned, do the orginal way
3. For sites with models assigned, adapt that sql query

Try to get balance, of simple solution vs compleciated and doing the job, and knowing we are moving to quartz-api

#217 

## How Has This Been Tested?

- [x] CI tests
- [x] ran locally and check NL models are returned, (where model name is not the latest forecast made)
- [x] check running for ~50 UK sites, that its similar to UI

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
