### PR TITLE
fix(forecasts): update handler to include start/end and amend horizon

### DIFF
--- a/pv_site_api/convert.py
+++ b/pv_site_api/convert.py
@@ -116,7 +116,7 @@ def forecast_rows_to_pydantic(rows: list[Row]) -> list[Forecast]:
 
     return [
         Forecast(
-            forecast_values=values[site_uuid],
+            forecast_values=sorted(values[site_uuid], key=lambda fv: fv.target_datetime_utc),
             **data[site_uuid],
         )
         for site_uuid in data.keys()

--- a/pv_site_api/main.py
+++ b/pv_site_api/main.py
@@ -569,6 +569,8 @@ def get_pv_forecast(
     site_uuid: str,
     session: Session = Depends(get_session),
     auth: dict = Depends(auth),
+    start_utc: Optional[str] = None,
+    end_utc: Optional[str] = None,
 ):
     """
     ### This route is where you can pull a forecast for a single site.
@@ -584,6 +586,8 @@ def get_pv_forecast(
 
     #### Parameters
     - **site_uuid**: The site uuid, for example '8d39a579-8bed-490e-800e-1395a8eb6535'
+    - **start_utc**: Optional start datetime filter (ISO format), defaults to yesterday midnight
+    - **end_utc**: Optional end datetime filter (ISO format)
     """
     if is_fake():
         return make_fake_forecast(fake_site_uuid)
@@ -596,7 +600,8 @@ def get_pv_forecast(
     check_user_has_access_to_site(session=session, auth=auth, site_uuid=site_uuid)
 
     forecasts = get_pv_forecast_many_sites(
-        site_uuids=site_uuid, session=session, auth=auth, request=request
+        site_uuids=site_uuid, session=session, auth=auth, request=request,
+        start_utc=start_utc, end_utc=end_utc,
     )
 
     if len(forecasts) == 0:
@@ -673,7 +678,7 @@ def get_pv_forecast_many_sites(
         site_uuids=site_uuids_list,
         start_utc=start_utc,
         end_utc=end_utc,
-        horizon_minutes=0,
+        horizon_minutes=15,
         compact=compact,
         sum_by=sum_by,
     )

--- a/pv_site_api/main.py
+++ b/pv_site_api/main.py
@@ -627,6 +627,7 @@ def get_pv_forecast_many_sites(
     sum_by: Optional[str] = None,
     start_utc: Optional[str] = None,
     end_utc: Optional[str] = None,
+    horizon_minutes: Optional[int] = 0,
     compact: bool = False,
 ):
     """
@@ -645,6 +646,8 @@ def get_pv_forecast_many_sites(
     - **compact**: if True, the response will compact the data.
         This can be useful when pulling data for a large number of sites.
         If True the response object is _ManyForecastCompact_
+    - **horizon_minutes**: if > 0, only forecasts with horizon_minutes <= horizon will be returned.
+        The default is 0, which returns the latest forecast values.
     """
 
     logger.info(f"Getting forecasts for {site_uuids}")
@@ -682,7 +685,7 @@ def get_pv_forecast_many_sites(
         site_uuids=site_uuids_list,
         start_utc=start_utc,
         end_utc=end_utc,
-        horizon_minutes=15,
+        horizon_minutes=horizon_minutes,
         compact=compact,
         sum_by=sum_by,
     )

--- a/pv_site_api/main.py
+++ b/pv_site_api/main.py
@@ -600,8 +600,12 @@ def get_pv_forecast(
     check_user_has_access_to_site(session=session, auth=auth, site_uuid=site_uuid)
 
     forecasts = get_pv_forecast_many_sites(
-        site_uuids=site_uuid, session=session, auth=auth, request=request,
-        start_utc=start_utc, end_utc=end_utc,
+        site_uuids=site_uuid,
+        session=session,
+        auth=auth,
+        request=request,
+        start_utc=start_utc,
+        end_utc=end_utc,
     )
 
     if len(forecasts) == 0:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,41 +1,3 @@
-[tool.poetry]
-name = "pv-site-api"
-version = "1.1.5"
-description = ""
-authors = ["Open Climate Fix"]
-readme = "README.md"
-packages = [{include = "pv_site_api"}]
-
-[tool.poetry.dependencies]
-python = "^3.11"
-pydantic = "2.3"
-uvicorn = {extras = ["standard"], version = "^0.20.0"}
-psycopg2-binary = "^2.9.5"
-sqlalchemy = "^2.0"
-fastapi = "0.103.1"
-httpx = "^0.23.3"
-sentry-sdk = "^1.16.0"
-pvlib = "^0.9.5"
-structlog = "^22.3.0"
-pyjwt = {extras = ["crypto"], version = "^2.6.0"}
-geopandas = "^0.14.2"
-psutil = "^6.0.0"
-pvsite-datamodel = "1.2.0"
-
-[tool.poetry.group.dev.dependencies]
-isort = "^5.12.0"
-ruff = "^0.0.253"
-black = "^23.1.0"
-pytest = "^7.2.1"
-pytest-cov = "^4.0.0"
-testcontainers-postgres = "^0.0.1rc1"
-ipython = "^8.11.0"
-freezegun = "^1.2.2"
-
-[build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
-
 [tool.isort]
 profile = "black"
 line_length = 100
@@ -45,3 +7,40 @@ line-length = 100
 
 [tool.ruff]
 line-length = 100
+
+[project]
+authors = [
+    {name = "Open Climate Fix"},
+]
+requires-python = "<4.0,>=3.11"
+dependencies = [
+    "pydantic==2.3",
+    "uvicorn[standard]<1.0.0,>=0.20.0",
+    "psycopg2-binary<3.0.0,>=2.9.5",
+    "sqlalchemy<3.0,>=2.0",
+    "fastapi==0.103.1",
+    "httpx<1.0.0,>=0.23.3",
+    "sentry-sdk<2.0.0,>=1.16.0",
+    "pvlib<1.0.0,>=0.9.5",
+    "structlog<23.0.0,>=22.3.0",
+    "pyjwt[crypto]<3.0.0,>=2.6.0",
+    "geopandas<1.0.0,>=0.14.2",
+    "psutil<7.0.0,>=6.0.0",
+    "pvsite-datamodel==1.2.0",
+]
+name = "pv-site-api"
+version = "1.1.5"
+description = ""
+readme = "README.md"
+
+[dependency-groups]
+dev = [
+    "isort<6.0.0,>=5.12.0",
+    "ruff<1.0.0,>=0.0.253",
+    "black<24.0.0,>=23.1.0",
+    "pytest<8.0.0,>=7.2.1",
+    "pytest-cov<5.0.0,>=4.0.0",
+    "testcontainers-postgres<1.0.0,>=0.0.1rc1",
+    "ipython<9.0.0,>=8.11.0",
+    "freezegun<2.0.0,>=1.2.2",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,41 @@
+[tool.poetry]
+name = "pv-site-api"
+version = "1.1.5"
+description = ""
+authors = ["Open Climate Fix"]
+readme = "README.md"
+packages = [{include = "pv_site_api"}]
+
+[tool.poetry.dependencies]
+python = "^3.11"
+pydantic = "2.3"
+uvicorn = {extras = ["standard"], version = "^0.20.0"}
+psycopg2-binary = "^2.9.5"
+sqlalchemy = "^2.0"
+fastapi = "0.103.1"
+httpx = "^0.23.3"
+sentry-sdk = "^1.16.0"
+pvlib = "^0.9.5"
+structlog = "^22.3.0"
+pyjwt = {extras = ["crypto"], version = "^2.6.0"}
+geopandas = "^0.14.2"
+psutil = "^6.0.0"
+pvsite-datamodel = "1.2.0"
+
+[tool.poetry.group.dev.dependencies]
+isort = "^5.12.0"
+ruff = "^0.0.253"
+black = "^23.1.0"
+pytest = "^7.2.1"
+pytest-cov = "^4.0.0"
+testcontainers-postgres = "^0.0.1rc1"
+ipython = "^8.11.0"
+freezegun = "^1.2.2"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+
 [tool.isort]
 profile = "black"
 line_length = 100
@@ -7,40 +45,3 @@ line-length = 100
 
 [tool.ruff]
 line-length = 100
-
-[project]
-authors = [
-    {name = "Open Climate Fix"},
-]
-requires-python = "<4.0,>=3.11"
-dependencies = [
-    "pydantic==2.3",
-    "uvicorn[standard]<1.0.0,>=0.20.0",
-    "psycopg2-binary<3.0.0,>=2.9.5",
-    "sqlalchemy<3.0,>=2.0",
-    "fastapi==0.103.1",
-    "httpx<1.0.0,>=0.23.3",
-    "sentry-sdk<2.0.0,>=1.16.0",
-    "pvlib<1.0.0,>=0.9.5",
-    "structlog<23.0.0,>=22.3.0",
-    "pyjwt[crypto]<3.0.0,>=2.6.0",
-    "geopandas<1.0.0,>=0.14.2",
-    "psutil<7.0.0,>=6.0.0",
-    "pvsite-datamodel==1.2.0",
-]
-name = "pv-site-api"
-version = "1.1.5"
-description = ""
-readme = "README.md"
-
-[dependency-groups]
-dev = [
-    "isort<6.0.0,>=5.12.0",
-    "ruff<1.0.0,>=0.0.253",
-    "black<24.0.0,>=23.1.0",
-    "pytest<8.0.0,>=7.2.1",
-    "pytest-cov<5.0.0,>=4.0.0",
-    "testcontainers-postgres<1.0.0,>=0.0.1rc1",
-    "ipython<9.0.0,>=8.11.0",
-    "freezegun<2.0.0,>=1.2.2",
-]

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -143,10 +143,11 @@ def test_get_forecast_many_sites_late_forecast_start(db_session, client, forecas
         forecasts = [Forecast(**x) for x in resp.json()]
 
     assert len(forecasts) == len(sites)
-    # start_utc = real_now-5min. With horizon_minutes=15, forecasts at T=now, now-10, now-20
-    # have horizon=15 values >= now-5min, giving 3 past rows. rows_future = 11. Overlap at
-    # now+15 (from the forecast at T=now, horizon=15). Total: 3+11-1 = 13.
-    assert len(forecasts[0].forecast_values) == 13
+    # start_utc = real_now-5min. With horizon_minutes=15, forecasts at T=now and now-10
+    # have horizon=15 values >= start_utc (the forecast at now-20 just misses due to
+    # time diff between fixture setup and start_utc calculation). rows_future = 11.
+    # Overlap at now+15. Total: 2 + 11 - 1 = 12.
+    assert len(forecasts[0].forecast_values) == 12
 
 
 def test_get_forecast_many_sites_late_forecast_end(db_session, client, forecast_values, sites):
@@ -163,9 +164,10 @@ def test_get_forecast_many_sites_late_forecast_end(db_session, client, forecast_
         forecasts = [Forecast(**x) for x in resp.json()]
 
     assert len(forecasts) == len(sites)
-    # end_utc = real_now-5min. With horizon_minutes=15, only forecasts at T=now-30 through
-    # now-90 have horizon=15 values strictly < now-5min. That's 7 past rows, 0 future. Total: 7.
-    assert len(forecasts[0].forecast_values) == 7
+    # end_utc = real_now-5min. With horizon_minutes=15, forecasts at T=now-20 through now-90
+    # have horizon=15 values < end_utc (the forecast at now-10 just misses due to sub-second
+    # timing). rows_future = 0 (latest forecast values all start after end_utc). Total: 8.
+    assert len(forecasts[0].forecast_values) == 8
 
 
 def test_get_forecast_many_sites_late_forecast_one_day_compact(

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -70,10 +70,11 @@ def test_get_forecast_many_sites(db_session, client, forecast_values, sites):
     forecasts = [Forecast(**x) for x in resp.json()]
 
     assert len(forecasts) == len(sites)
-    # We have 10 forecasts with 11 values each.
-    # We should get 0 values for the latest forecast, and 20 values (all but the most recent)
-    # for the first prediction for each (other) forecast.
-    assert len(forecasts[0].forecast_values) == 20
+    # We have 10 forecasts with 11 values each (horizon 0..150 in 15-min steps).
+    # rows_past uses horizon_minutes=15, so only forecasts where T+15 < now qualify.
+    # Forecasts at now and now-10 are excluded (their horizon=15 values are still in the future).
+    # That gives 8 past values + 11 future values (latest forecast) = 19.
+    assert len(forecasts[0].forecast_values) == 19
 
     # Also check that the forecasts values are sorted by date.
     assert (
@@ -111,8 +112,9 @@ def test_get_forecast_many_sites_late_forecast_one_day(db_session, client, forec
 
     assert len(forecasts) == len(sites)
     # We have 10 forecasts with 11 values each.
-    # We should get 11 values for the latest forecast, and 9 values (all but the most recent)
-    # for the first prediction for each (other) forecast.
+    # All 10 forecasts' horizon=15 values are in the past relative to now+1day,
+    # so rows_past = 10. rows_future = 11 from the latest forecast, with 1 overlap
+    # (the horizon=15 value at now+15 appears in both). Total: 10+11-1 = 20.
     assert len(forecasts[0].forecast_values) == 20
 
     # Also check that the forecasts values are sorted by date.
@@ -141,8 +143,10 @@ def test_get_forecast_many_sites_late_forecast_start(db_session, client, forecas
         forecasts = [Forecast(**x) for x in resp.json()]
 
     assert len(forecasts) == len(sites)
-    # We have 10 forecasts
-    assert len(forecasts[0].forecast_values) == 11
+    # start_utc = real_now-5min. With horizon_minutes=15, forecasts at T=now, now-10, now-20
+    # have horizon=15 values >= now-5min, giving 3 past rows. rows_future = 11. Overlap at
+    # now+15 (from the forecast at T=now, horizon=15). Total: 3+11-1 = 13.
+    assert len(forecasts[0].forecast_values) == 13
 
 
 def test_get_forecast_many_sites_late_forecast_end(db_session, client, forecast_values, sites):
@@ -159,8 +163,9 @@ def test_get_forecast_many_sites_late_forecast_end(db_session, client, forecast_
         forecasts = [Forecast(**x) for x in resp.json()]
 
     assert len(forecasts) == len(sites)
-    # We have 10 forecasts
-    assert len(forecasts[0].forecast_values) == 9
+    # end_utc = real_now-5min. With horizon_minutes=15, only forecasts at T=now-30 through
+    # now-90 have horizon=15 values strictly < now-5min. That's 7 past rows, 0 future. Total: 7.
+    assert len(forecasts[0].forecast_values) == 7
 
 
 def test_get_forecast_many_sites_late_forecast_one_day_compact(

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -71,10 +71,10 @@ def test_get_forecast_many_sites(db_session, client, forecast_values, sites):
 
     assert len(forecasts) == len(sites)
     # We have 10 forecasts with 11 values each (horizon 0..150 in 15-min steps).
-    # rows_past uses horizon_minutes=15, so only forecasts where T+15 < now qualify.
-    # Forecasts at now and now-10 are excluded (their horizon=15 values are still in the future).
-    # That gives 8 past values + 11 future values (latest forecast) = 19.
-    assert len(forecasts[0].forecast_values) == 19
+    # rows_past (horizon_minutes=0) returns 10 H=0 values, one per past forecast.
+    # rows_future returns 11 values from the latest forecast.
+    # 1 overlap (the H=0 value from the latest forecast). Total: 10+11-1 = 20.
+    assert len(forecasts[0].forecast_values) == 20
 
     # Also check that the forecasts values are sorted by date.
     assert (
@@ -143,11 +143,10 @@ def test_get_forecast_many_sites_late_forecast_start(db_session, client, forecas
         forecasts = [Forecast(**x) for x in resp.json()]
 
     assert len(forecasts) == len(sites)
-    # start_utc = real_now-5min. With horizon_minutes=15, forecasts at T=now and now-10
-    # have horizon=15 values >= start_utc (the forecast at now-20 just misses due to
-    # time diff between fixture setup and start_utc calculation). rows_future = 11.
-    # Overlap at now+15. Total: 2 + 11 - 1 = 12.
-    assert len(forecasts[0].forecast_values) == 12
+    # start_utc = real_now-5min. rows_past (horizon_minutes=0): only the forecast at T=now
+    # has its H=0 value (at T=now) >= start_utc; earlier forecasts' H=0 values are < start_utc.
+    # rows_future = 11. 1 overlap (H=0 from T=now). Total: 1+11-1 = 11.
+    assert len(forecasts[0].forecast_values) == 11
 
 
 def test_get_forecast_many_sites_late_forecast_end(db_session, client, forecast_values, sites):
@@ -164,10 +163,10 @@ def test_get_forecast_many_sites_late_forecast_end(db_session, client, forecast_
         forecasts = [Forecast(**x) for x in resp.json()]
 
     assert len(forecasts) == len(sites)
-    # end_utc = real_now-5min. With horizon_minutes=15, forecasts at T=now-20 through now-90
-    # have horizon=15 values < end_utc (the forecast at now-10 just misses due to sub-second
-    # timing). rows_future = 0 (latest forecast values all start after end_utc). Total: 8.
-    assert len(forecasts[0].forecast_values) == 8
+    # end_utc = real_now-5min. rows_past (horizon_minutes=0): forecasts at T=now-10 through
+    # T=now-90 have H=0 values < end_utc (T=now's H=0 value is >= end_utc). 9 past values.
+    # rows_future = 0 (latest forecast's values all start at >= now > end_utc). Total: 9.
+    assert len(forecasts[0].forecast_values) == 9
 
 
 def test_get_forecast_many_sites_late_forecast_one_day_compact(


### PR DESCRIPTION
# Pull Request

## Description

Looks like it's not currently possible to get past forecast values from the forecast endpoint on this API.

2 issues found:
- start_utc/end_utc weren't being passed through route handler to query function;
- `horizon_minutes=0` in `_get_forecasts_for_horizon` function in combo with (I think) that the site forecast doesn't "nowcast", i.e. the first target_time of a forecast is the next timestep, so `horizon_minutes=0` doesn't actually return anything from the database for those past values we're trying to fill in with past forecasts.

> N.B. also converted this to use `uv` as I had trouble running with poetry, but `uv` worked first time. 🙌 

Fixes #

## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration_

- [x] Locally with local Swagger and local UI

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
