### PR TITLE
feat(apitally): add API monitoring

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -32,6 +32,34 @@ test = ["anyio[trio]", "coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "mock (>=
 trio = ["trio (<0.22)"]
 
 [[package]]
+name = "apitally"
+version = "0.24.4"
+description = "Simple API monitoring & analytics for REST APIs built with FastAPI, Flask, Django, Starlette, Litestar and BlackSheep."
+optional = false
+python-versions = "<4.0,>=3.9"
+files = [
+    {file = "apitally-0.24.4-py3-none-any.whl", hash = "sha256:764f3c9dc907ec2014f8f420d66db091826106eb7b306ce871238c647029a019"},
+    {file = "apitally-0.24.4.tar.gz", hash = "sha256:78447204cb1b0e6b409129ae8b13ddcdfe03bab648af8662cd73fc24a8e30ec2"},
+]
+
+[package.dependencies]
+backoff = ">=2.0.0"
+fastapi = {version = ">=0.94.1", optional = true, markers = "extra == \"fastapi\""}
+httpx = {version = ">=0.22.0", optional = true, markers = "extra == \"fastapi\""}
+opentelemetry-sdk = ">=1.39.1,<2.0.0"
+psutil = ">=5.9.6"
+starlette = {version = ">=0.26.1,<2.0.0", optional = true, markers = "extra == \"fastapi\""}
+
+[package.extras]
+blacksheep = ["blacksheep (>=2)", "httpx (>=0.22.0)"]
+django-ninja = ["django (>=2.2)", "django (>=2.2,<5)", "django-ninja (>=1.0.0)", "requests (>=2.26.0)"]
+django-rest-framework = ["django (>=2.2)", "django (>=2.2,<5)", "djangorestframework (>=3.10.0)", "inflection (>=0.5.1)", "requests (>=2.26.0)", "uritemplate (>=3.0.0)"]
+fastapi = ["fastapi (>=0.94.1)", "httpx (>=0.22.0)", "starlette (>=0.26.1,<2.0.0)"]
+flask = ["flask (>=2.0.0)", "requests (>=2.26.0)"]
+litestar = ["httpx (>=0.22.0)", "litestar (>=2.4.0)"]
+starlette = ["httpx (>=0.22.0)", "starlette (>=0.26.1,<2.0.0)"]
+
+[[package]]
 name = "asttokens"
 version = "2.4.1"
 description = "Annotate AST trees with source code positions"
@@ -67,6 +95,17 @@ docs = ["furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-
 tests = ["attrs[tests-no-zope]", "zope-interface"]
 tests-mypy = ["mypy (>=1.6)", "pytest-mypy-plugins"]
 tests-no-zope = ["attrs[tests-mypy]", "cloudpickle", "hypothesis", "pympler", "pytest (>=4.3.0)", "pytest-xdist[psutil]"]
+
+[[package]]
+name = "backoff"
+version = "2.2.1"
+description = "Function decoration for backoff and retry"
+optional = false
+python-versions = ">=3.7,<4.0"
+files = [
+    {file = "backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8"},
+    {file = "backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba"},
+]
 
 [[package]]
 name = "black"
@@ -831,6 +870,29 @@ files = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "8.7.1"
+description = "Read metadata from Python packages"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151"},
+    {file = "importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb"},
+]
+
+[package.dependencies]
+zipp = ">=3.20"
+
+[package.extras]
+check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)"]
+cover = ["pytest-cov"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+enabler = ["pytest-enabler (>=3.4)"]
+perf = ["ipython"]
+test = ["flufl.flake8", "jaraco.test (>=5.4)", "packaging", "pyfakefs", "pytest (>=6,!=8.1.*)", "pytest-perf (>=0.9.2)"]
+type = ["mypy (<1.19)", "pytest-mypy (>=1.0.1)"]
+
+[[package]]
 name = "iniconfig"
 version = "2.0.0"
 description = "brain-dead simple config-ini parsing"
@@ -978,6 +1040,55 @@ files = [
     {file = "numpy-1.26.4-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:7e50d0a0cc3189f9cb0aeb3a6a6af18c16f59f004b866cd2be1c14b36134a4a0"},
     {file = "numpy-1.26.4.tar.gz", hash = "sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010"},
 ]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.41.1"
+description = "OpenTelemetry Python API"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "opentelemetry_api-1.41.1-py3-none-any.whl", hash = "sha256:a22df900e75c76dc08440710e51f52f1aa6b451b429298896023e60db5b3139f"},
+    {file = "opentelemetry_api-1.41.1.tar.gz", hash = "sha256:0ad1814d73b875f84494387dae86ce0b12c68556331ce6ce8fe789197c949621"},
+]
+
+[package.dependencies]
+importlib-metadata = ">=6.0,<8.8.0"
+typing-extensions = ">=4.5.0"
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.41.1"
+description = "OpenTelemetry Python SDK"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "opentelemetry_sdk-1.41.1-py3-none-any.whl", hash = "sha256:edee379c126c1bce952b0c812b48fe8ff35b30df0eecf17e98afa4d598b7d85d"},
+    {file = "opentelemetry_sdk-1.41.1.tar.gz", hash = "sha256:724b615e1215b5aeacda0abb8a6a8922c9a1853068948bd0bd225a56d0c792e6"},
+]
+
+[package.dependencies]
+opentelemetry-api = "1.41.1"
+opentelemetry-semantic-conventions = "0.62b1"
+typing-extensions = ">=4.5.0"
+
+[package.extras]
+file-configuration = ["jsonschema (>=4.0)", "pyyaml (>=6.0)"]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.62b1"
+description = "OpenTelemetry Semantic Conventions"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "opentelemetry_semantic_conventions-0.62b1-py3-none-any.whl", hash = "sha256:cf506938103d331fbb78eded0d9788095f7fd59016f2bda813c3324e5a74a93c"},
+    {file = "opentelemetry_semantic_conventions-0.62b1.tar.gz", hash = "sha256:c5cc6e04a7f8c7cdd30be2ed81499fa4e75bfbd52c9cb70d40af1f9cd3619802"},
+]
+
+[package.dependencies]
+opentelemetry-api = "1.41.1"
+typing-extensions = ">=4.5.0"
 
 [[package]]
 name = "packaging"
@@ -2500,7 +2611,26 @@ files = [
     {file = "wrapt-1.16.0.tar.gz", hash = "sha256:5f370f952971e7d17c7d1ead40e49f32345a7f7a5373571ef44d800d06b1899d"},
 ]
 
+[[package]]
+name = "zipp"
+version = "3.23.1"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "zipp-3.23.1-py3-none-any.whl", hash = "sha256:0b3596c50a5c700c9cb40ba8d86d9f2cc4807e9bedb06bcdf7fac85633e444dc"},
+    {file = "zipp-3.23.1.tar.gz", hash = "sha256:32120e378d32cd9714ad503c1d024619063ec28aad2248dc6672ad13edfa5110"},
+]
+
+[package.extras]
+check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)"]
+cover = ["pytest-cov"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+enabler = ["pytest-enabler (>=2.2)"]
+test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more_itertools", "pytest (>=6,!=8.1.*)", "pytest-ignore-flaky"]
+type = ["pytest-mypy"]
+
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "5c2a5742277883330e166795e1a04e43142f7e6e6f8b7f03da3644d9cae550c4"
+content-hash = "0f5d8ecb7c2f82ba87bcf2efce4ec86581e77944c8f27041fbf944a80de326bb"

--- a/pv_site_api/auth.py
+++ b/pv_site_api/auth.py
@@ -1,5 +1,6 @@
 import jwt
-from fastapi import Depends, HTTPException
+from apitally.fastapi import set_consumer
+from fastapi import Depends, HTTPException, Request
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 token_auth_scheme = HTTPBearer()
@@ -15,7 +16,11 @@ class Auth:
 
         self._jwks_client = jwt.PyJWKClient(f"https://{domain}/.well-known/jwks.json")
 
-    def __call__(self, auth_credentials: HTTPAuthorizationCredentials = Depends(token_auth_scheme)):
+    def __call__(
+        self,
+        request: Request,
+        auth_credentials: HTTPAuthorizationCredentials = Depends(token_auth_scheme),
+    ):
         token = auth_credentials.credentials
 
         try:
@@ -33,5 +38,9 @@ class Auth:
             )
         except Exception as e:
             raise HTTPException(status_code=401, detail=str(e))
+
+        email = payload.get("https://openclimatefix.org/email")
+        if email:
+            set_consumer(request, identifier=email)
 
         return payload

--- a/pv_site_api/main.py
+++ b/pv_site_api/main.py
@@ -9,6 +9,7 @@ from typing import Optional, Union
 import pandas as pd
 import sentry_sdk
 import structlog
+from apitally.fastapi import ApitallyMiddleware
 from dotenv import load_dotenv
 from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -136,6 +137,16 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+apitally_client_id = os.getenv("APITALLY_CLIENT_ID")
+
+if apitally_client_id:
+    app.add_middleware(
+        ApitallyMiddleware,
+        client_id=apitally_client_id,
+        env=os.getenv("ENVIRONMENT", "local"),
+        enable_request_logging=True,
+    )
 
 auth = Auth(
     domain=os.getenv("AUTH0_DOMAIN"),

--- a/pv_site_api/main.py
+++ b/pv_site_api/main.py
@@ -144,7 +144,7 @@ if apitally_client_id:
     app.add_middleware(
         ApitallyMiddleware,
         client_id=apitally_client_id,
-        env=os.getenv("ENVIRONMENT", "local"),
+        env=os.getenv("APITALLY_ENVIRONMENT", "local"),
         enable_request_logging=True,
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ pyjwt = {extras = ["crypto"], version = "^2.6.0"}
 geopandas = "^0.14.2"
 psutil = "^6.0.0"
 pvsite-datamodel = "1.2.0"
+apitally = {extras = ["fastapi"], version = "^0.24.4"}
 
 [tool.poetry.group.dev.dependencies]
 isort = "^5.12.0"


### PR DESCRIPTION
# Pull Request

## Description

Adds Apitally monitoring to the PV Site API.

This change:
- adds `apitally[fastapi]` as a dependency
- enables `ApitallyMiddleware` when `APITALLY_CLIENT_ID` is configured
- sets the Apitally consumer from the authenticated user's email address

This follows the same general approach used in `quartz-api`, while keeping Apitally disabled for local/test environments unless configured.

Fixes #222

## How Has This Been Tested?

I verified that the changed files compile successfully:

- `poetry run python -m compileall pv_site_api/main.py pv_site_api/auth.py`

I also verified that the touched files pass formatting and lint checks:

- `poetry run black --check pv_site_api/auth.py pv_site_api/main.py`
- `poetry run ruff check pv_site_api/auth.py pv_site_api/main.py`

I attempted to run the auth tests:

- `poetry run pytest tests/test_auth.py`

This did not complete locally because the test setup requires Docker to start a Postgres test container via `PostgresContainer("postgres:14.5")`, and Docker was not available in my local Windows environment. The failure occurred during test fixture setup while connecting to `//./pipe/docker_engine`, before the auth tests themselves ran.

- [x] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

No data processing changes.

- [ ] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
