### PR TITLE
Update locations

### DIFF
--- a/pv_site_api/dataplatform_client.py
+++ b/pv_site_api/dataplatform_client.py
@@ -105,3 +105,107 @@ async def send_generation_data_to_platform(
             exc_info=True,
         )
         sentry_sdk.capture_exception(exc)
+
+
+async def create_dataplatform_location(
+    site_uuid: str,
+    client_site_name: str,
+    latitude: float,
+    longitude: float,
+    capacity_kw: float,
+) -> None:
+    """
+    Register a new PV site as a location with the OCF Data Platform via gRPC CreateLocation.
+
+    The location is created with `location_name` set to the site's own UUID (rather than its
+    client-facing name) so that later observation streaming, which looks up locations via
+    `location_uuid=site_uuid`, resolves correctly.
+    :param site_uuid: UUID string of the newly created PV site
+    :param client_site_name: client-facing site name, used for logging only
+    :param latitude: site latitude
+    :param longitude: site longitude
+    :param capacity_kw: site capacity in kW
+    """
+    target = get_dataplatform_target()
+
+    logger.info(
+        f"Creating Data Platform location for site {site_uuid} ({client_site_name}) at {target}"
+    )
+
+    try:
+        ts = Timestamp()
+        ts.FromDatetime(datetime.now(timezone.utc))
+
+        req = messages_pb2.CreateLocationRequest(
+            location_name=str(site_uuid),
+            energy_source=common_pb2.EnergySource.ENERGY_SOURCE_SOLAR,
+            effective_capacity_watts=round(capacity_kw * 1000.0),
+            location_type=common_pb2.LocationType.LOCATION_TYPE_SITE,
+            valid_from_utc=ts,
+            associated_latlng=common_pb2.LatLng(latitude=latitude, longitude=longitude),
+        )
+
+        async with get_dataplatform_channel(target) as channel:
+            client = service_pb2_grpc.DataPlatformDataServiceStub(channel)
+            await client.CreateLocation(req, timeout=5.0)
+
+        logger.info(f"Successfully created Data Platform location for site {site_uuid}.")
+
+    except Exception as exc:
+        logger.error(
+            f"Failed to create Data Platform location for site {site_uuid}: {exc}",
+            exc_info=True,
+        )
+        sentry_sdk.capture_exception(exc)
+
+
+async def update_dataplatform_location(
+    site_uuid: str,
+    client_site_name: str,
+    latitude: float,
+    longitude: float,
+    capacity_kw: float,
+) -> None:
+    """
+    Update an existing Data Platform location via gRPC UpdateLocation.
+
+    The site's own UUID is passed directly as `location_uuid`, matching the assumption already
+    made by `send_generation_data_to_platform` that this app's site UUID is the Data Platform
+    location UUID.
+    :param site_uuid: UUID string of the PV site, used directly as the Data Platform location_uuid
+    :param client_site_name: client-facing site name, set as the location's new name
+    :param latitude: site latitude (unused: UpdateLocationRequest has no lat/lng field, kept for a
+        symmetric call signature with create_dataplatform_location)
+    :param longitude: site longitude (unused, see latitude)
+    :param capacity_kw: site capacity in kW
+    """
+    target = get_dataplatform_target()
+
+    logger.info(
+        f"Updating Data Platform location for site {site_uuid} ({client_site_name}) at {target}"
+    )
+
+    try:
+        ts = Timestamp()
+        ts.FromDatetime(datetime.now(timezone.utc))
+
+        req = messages_pb2.UpdateLocationRequest(
+            location_uuid=str(site_uuid),
+            energy_source=common_pb2.EnergySource.ENERGY_SOURCE_SOLAR,
+            new_location_name=client_site_name,
+            new_effective_capacity_watts=round(capacity_kw * 1000.0),
+            valid_from_utc=ts,
+        )
+
+        async with get_dataplatform_channel(target) as channel:
+            client = service_pb2_grpc.DataPlatformDataServiceStub(channel)
+            await client.UpdateLocation(req, timeout=5.0)
+
+        logger.info(f"Successfully updated Data Platform location for site {site_uuid}.")
+
+    except Exception as exc:
+        logger.error(
+            f"Failed to update Data Platform location for site {site_uuid}: {exc}",
+            exc_info=True,
+        )
+        sentry_sdk.capture_exception(exc)

--- a/pv_site_api/dataplatform_client.py
+++ b/pv_site_api/dataplatform_client.py
@@ -1,6 +1,7 @@
 """Data Platform Client for forwarding generation observations to OCF Data Platform."""
 
 import os
+import re
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
@@ -8,6 +9,7 @@ import grpc
 import sentry_sdk
 import structlog
 from fastapi import HTTPException
+from google.protobuf.struct_pb2 import Struct
 from google.protobuf.timestamp_pb2 import Timestamp
 from ocf.dp.dp import common_pb2
 from ocf.dp.dp_data import messages_pb2, service_pb2_grpc
@@ -20,6 +22,16 @@ def get_dataplatform_target() -> str:
     host = os.getenv("DATA_PLATFORM_HOST", "localhost")
     port = os.getenv("DATA_PLATFORM_PORT", "50051")
     return f"{host}:{port}"
+
+
+def _sanitize_location_name(name: str) -> str:
+    """
+    Convert a client-facing name into a valid Data Platform location_name.
+
+    Data Platform requires location_name to be 2-100 chars, lowercase alphanumeric,
+    underscores, and pipes only. Any other character is replaced with an underscore.
+    """
+    return re.sub(r"[^a-z0-9_|]", "_", name.lower())
 
 
 def _parse_datetime(dt_val: Any) -> datetime:
@@ -60,7 +72,7 @@ class DataPlatformClient:
         if not client_location_name:
             return None
 
-        target_names = {client_location_name, client_location_name.replace(".", "_")}
+        target_names = {client_location_name, _sanitize_location_name(client_location_name)}
 
         try:
             req = messages_pb2.ListLocationsRequest(location_names_filter=list(target_names))
@@ -133,6 +145,116 @@ class DataPlatformClient:
             logger.error(
                 f"Failed to send generation observations to Data Platform "
                 f"for site {site_uuid}: {exc}",
+                exc_info=True,
+            )
+            sentry_sdk.capture_exception(exc)
+
+    async def create_location(
+        self,
+        site_uuid: str,
+        client_site_name: str,
+        latitude: float,
+        longitude: float,
+        capacity_kw: float,
+    ) -> None:
+        """
+        Register a new PV site as a location with the OCF Data Platform via gRPC CreateLocation.
+
+        `location_name` must be lowercase alphanumeric/underscore/pipe only, so it's derived
+        from `client_site_name` by replacing any other character with an underscore (matching
+        `resolve_site_uuid`'s lookup). The original, unsanitized name is preserved in `metadata`.
+        :param site_uuid: UUID string of the newly created PV site, used only for logging
+        :param client_site_name: the site's client-facing name
+        :param latitude: site latitude
+        :param longitude: site longitude
+        :param capacity_kw: site capacity in kW
+        """
+        logger.info(f"Creating Data Platform location for site {site_uuid} ({client_site_name})")
+
+        try:
+            ts = Timestamp()
+            ts.FromDatetime(datetime.now(timezone.utc))
+
+            metadata = Struct()
+            metadata.update({"client_location_name": client_site_name})
+
+            req = messages_pb2.CreateLocationRequest(
+                location_name=_sanitize_location_name(client_site_name),
+                energy_source=common_pb2.EnergySource.ENERGY_SOURCE_SOLAR,
+                geometry_wkt=f"POINT({longitude} {latitude})",
+                effective_capacity_watts=round(capacity_kw * 1000.0),
+                location_type=common_pb2.LocationType.LOCATION_TYPE_SITE,
+                valid_from_utc=ts,
+                metadata=metadata,
+            )
+
+            await self.stub.CreateLocation(req)
+
+            logger.info(f"Successfully created Data Platform location for site {site_uuid}.")
+
+        except Exception as exc:
+            logger.error(
+                f"Failed to create Data Platform location for site {site_uuid}: {exc}",
+                exc_info=True,
+            )
+            sentry_sdk.capture_exception(exc)
+
+    async def update_location(
+        self,
+        site_uuid: str,
+        current_client_site_name: str,
+        new_client_site_name: str,
+        capacity_kw: float,
+    ) -> None:
+        """
+        Update an existing Data Platform location via gRPC UpdateLocation.
+
+        Data Platform assigns its own `location_uuid` at creation time (independent of this
+        app's site UUID), so the location must be resolved by name first, the same way
+        `send_generation_data_to_platform`'s caller resolves it via `resolve_site_uuid`. It's
+        resolved by `current_client_site_name` (the name as currently registered on the Data
+        Platform) rather than `new_client_site_name`, since a rename means those may differ.
+        :param site_uuid: UUID string of the PV site, used only for logging
+        :param current_client_site_name: the site's client-facing name as currently registered
+            on the Data Platform, used to resolve the location to update
+        :param new_client_site_name: the site's client-facing name to update the location to
+        :param capacity_kw: site capacity in kW
+        """
+        dp_uuid = await self.resolve_site_uuid(current_client_site_name)
+        if dp_uuid is None:
+            logger.warning(
+                f"Skipping Data Platform location update: no location found for site "
+                f"{site_uuid} (client_site_name={current_client_site_name!r})"
+            )
+            return
+
+        logger.info(
+            f"Updating Data Platform location for site {site_uuid} ({new_client_site_name})"
+        )
+
+        try:
+            ts = Timestamp()
+            ts.FromDatetime(datetime.now(timezone.utc))
+
+            new_metadata = Struct()
+            new_metadata.update({"client_location_name": new_client_site_name})
+
+            req = messages_pb2.UpdateLocationRequest(
+                location_uuid=dp_uuid,
+                energy_source=common_pb2.EnergySource.ENERGY_SOURCE_SOLAR,
+                new_location_name=_sanitize_location_name(new_client_site_name),
+                new_effective_capacity_watts=round(capacity_kw * 1000.0),
+                new_metadata=new_metadata,
+                valid_from_utc=ts,
+            )
+
+            await self.stub.UpdateLocation(req)
+
+            logger.info(f"Successfully updated Data Platform location for site {site_uuid}.")
+
+        except Exception as exc:
+            logger.error(
+                f"Failed to update Data Platform location for site {site_uuid}: {exc}",
                 exc_info=True,
             )
             sentry_sdk.capture_exception(exc)

--- a/pv_site_api/main.py
+++ b/pv_site_api/main.py
@@ -44,7 +44,12 @@ from ._db_helpers import (
 )
 from .auth import Auth
 from .cache import cache_response
-from .dataplatform_client import is_dataplatform_enabled, send_generation_data_to_platform
+from .dataplatform_client import (
+    create_dataplatform_location,
+    is_dataplatform_enabled,
+    send_generation_data_to_platform,
+    update_dataplatform_location,
+)
 from .fake import (
     fake_site_uuid,
     make_fake_forecast,
@@ -389,6 +394,17 @@ def put_site_info(
 
     logger.debug(message)
 
+    if is_dataplatform_enabled():
+        asyncio.run(
+            update_dataplatform_location(
+                site_uuid=site.location_uuid,
+                client_site_name=site.client_location_name,
+                latitude=site.latitude,
+                longitude=site.longitude,
+                capacity_kw=site.capacity_kw,
+            )
+        )
+
     return site_to_pydantic(site)
 
 
@@ -437,6 +453,17 @@ def post_site_info(
     # make sure the user is added to the site
     user.location_group.locations.append(site)
     session.commit()
+
+    if is_dataplatform_enabled():
+        asyncio.run(
+            create_dataplatform_location(
+                site_uuid=site.location_uuid,
+                client_site_name=site.client_location_name,
+                latitude=site.latitude,
+                longitude=site.longitude,
+                capacity_kw=site.capacity_kw,
+            )
+        )
 
     return site_to_pydantic(site)
 

--- a/pv_site_api/main.py
+++ b/pv_site_api/main.py
@@ -376,11 +376,12 @@ async def post_pv_actual(
 
 # put_site_info: client can update a site
 @app.put("/sites/{site_uuid}", response_model=PVSiteMetadata, tags=["Sites"])
-def put_site_info(
+async def put_site_info(
     site_uuid: str,
     site_info: PVSiteEditMetadata,
     session: Session = Depends(get_session),
     auth: dict = Depends(auth),
+    dp_client: DataPlatformClient = Depends(get_dataplatform_client),
 ) -> PVSiteMetadata:
     """
     ### This route allows a user to update site information for a single site.
@@ -406,30 +407,32 @@ def put_site_info(
     # make sure user has access to this site
     check_user_has_access_to_site(session=session, auth=auth, site_uuid=site_uuid)
 
+    # capture the current name before it's renamed, so the existing Data Platform
+    # location (registered under the current name) can still be resolved
+    current_site = get_site_by_uuid(session=session, site_uuid=site_uuid)
+    current_client_site_name = current_site.client_location_name
+
     # update site informations
     site, message = edit_site(session=session, site_uuid=site_uuid, site_info=site_info)
 
     logger.debug(message)
 
-    if is_dataplatform_enabled():
-        asyncio.run(
-            update_dataplatform_location(
-                site_uuid=site.location_uuid,
-                client_site_name=site.client_location_name,
-                latitude=site.latitude,
-                longitude=site.longitude,
-                capacity_kw=site.capacity_kw,
-            )
-        )
+    await dp_client.update_location(
+        site_uuid=site.location_uuid,
+        current_client_site_name=current_client_site_name,
+        new_client_site_name=site.client_location_name,
+        capacity_kw=site.capacity_kw,
+    )
 
     return site_to_pydantic(site)
 
 
 @app.post("/sites", status_code=201, response_model=PVSiteMetadata, tags=["Sites"])
-def post_site_info(
+async def post_site_info(
     site_info: PVSiteInputMetadata,
     session: Session = Depends(get_session),
     auth: dict = Depends(auth),
+    dp_client: DataPlatformClient = Depends(get_dataplatform_client),
 ) -> PVSiteMetadata:
     """
     ### This route allows a user to add a site.
@@ -471,16 +474,13 @@ def post_site_info(
     user.location_group.locations.append(site)
     session.commit()
 
-    if is_dataplatform_enabled():
-        asyncio.run(
-            create_dataplatform_location(
-                site_uuid=site.location_uuid,
-                client_site_name=site.client_location_name,
-                latitude=site.latitude,
-                longitude=site.longitude,
-                capacity_kw=site.capacity_kw,
-            )
-        )
+    await dp_client.create_location(
+        site_uuid=site.location_uuid,
+        client_site_name=site.client_location_name,
+        latitude=site.latitude,
+        longitude=site.longitude,
+        capacity_kw=site.capacity_kw,
+    )
 
     return site_to_pydantic(site)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,8 +12,26 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 from testcontainers.postgres import PostgresContainer
 
+from pv_site_api.dataplatform_client import DataPlatformClient
 from pv_site_api.main import app, auth
 from pv_site_api.session import get_session
+
+
+@pytest.fixture(autouse=True)
+def _stub_dataplatform_client(monkeypatch):
+    """Stub out all Data Platform gRPC calls by default so tests don't hit real network.
+
+    Tests that want to assert on Data Platform behavior override these with their own
+    monkeypatch.setattr(DataPlatformClient, ...) calls, which take precedence for that test.
+    """
+
+    async def _noop(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(DataPlatformClient, "resolve_site_uuid", _noop)
+    monkeypatch.setattr(DataPlatformClient, "send_generation_data_to_platform", _noop)
+    monkeypatch.setattr(DataPlatformClient, "create_location", _noop)
+    monkeypatch.setattr(DataPlatformClient, "update_location", _noop)
 
 
 @pytest.fixture

--- a/tests/test_dataplatform_client.py
+++ b/tests/test_dataplatform_client.py
@@ -6,7 +6,12 @@ from unittest.mock import AsyncMock, patch
 import pytest
 import sentry_sdk
 
-from pv_site_api.dataplatform_client import _parse_datetime, send_generation_data_to_platform
+from pv_site_api.dataplatform_client import (
+    _parse_datetime,
+    create_dataplatform_location,
+    send_generation_data_to_platform,
+    update_dataplatform_location,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -76,5 +81,111 @@ async def test_send_generation_grpc_failure_reports_to_sentry():
             with patch.object(sentry_sdk, "capture_exception") as mock_capture:
                 # Should not raise: failures are handled internally.
                 await send_generation_data_to_platform("test-site-uuid", records)
+
+                mock_capture.assert_called_once_with(grpc_error)
+
+
+@pytest.mark.asyncio
+async def test_create_dataplatform_location_enabled():
+    mock_stub = AsyncMock()
+    mock_channel = AsyncMock()
+    mock_channel.__aenter__.return_value = mock_channel
+
+    with patch("grpc.aio.insecure_channel", return_value=mock_channel):
+        with patch(
+            "ocf.dp.dp_data.service_pb2_grpc.DataPlatformDataServiceStub", return_value=mock_stub
+        ):
+            await create_dataplatform_location(
+                site_uuid="test-site-uuid",
+                client_site_name="Test Site",
+                latitude=51.5,
+                longitude=-0.1,
+                capacity_kw=2.5,
+            )
+
+            assert mock_stub.CreateLocation.called
+            req = mock_stub.CreateLocation.call_args[0][0]
+            assert req.location_name == "test-site-uuid"
+            # 2.5 kW -> 2500 Watts
+            assert req.effective_capacity_watts == 2500
+            # LatLng fields are proto float (32-bit), so compare with a tolerance.
+            assert req.associated_latlng.latitude == pytest.approx(51.5)
+            assert req.associated_latlng.longitude == pytest.approx(-0.1)
+
+
+@pytest.mark.asyncio
+async def test_create_dataplatform_location_grpc_failure_reports_to_sentry():
+    """If the gRPC call raises, the error is swallowed and reported to Sentry (not propagated)."""
+    mock_stub = AsyncMock()
+    grpc_error = RuntimeError("Data Platform unavailable")
+    mock_stub.CreateLocation.side_effect = grpc_error
+    mock_channel = AsyncMock()
+    mock_channel.__aenter__.return_value = mock_channel
+
+    with patch("grpc.aio.insecure_channel", return_value=mock_channel):
+        with patch(
+            "ocf.dp.dp_data.service_pb2_grpc.DataPlatformDataServiceStub", return_value=mock_stub
+        ):
+            with patch.object(sentry_sdk, "capture_exception") as mock_capture:
+                # Should not raise: failures are handled internally.
+                await create_dataplatform_location(
+                    site_uuid="test-site-uuid",
+                    client_site_name="Test Site",
+                    latitude=51.5,
+                    longitude=-0.1,
+                    capacity_kw=2.5,
+                )
+
+                mock_capture.assert_called_once_with(grpc_error)
+
+
+@pytest.mark.asyncio
+async def test_update_dataplatform_location_enabled():
+    mock_stub = AsyncMock()
+    mock_channel = AsyncMock()
+    mock_channel.__aenter__.return_value = mock_channel
+
+    with patch("grpc.aio.insecure_channel", return_value=mock_channel):
+        with patch(
+            "ocf.dp.dp_data.service_pb2_grpc.DataPlatformDataServiceStub", return_value=mock_stub
+        ):
+            await update_dataplatform_location(
+                site_uuid="test-site-uuid",
+                client_site_name="Updated Site",
+                latitude=51.5,
+                longitude=-0.1,
+                capacity_kw=3.0,
+            )
+
+            assert mock_stub.UpdateLocation.called
+            req = mock_stub.UpdateLocation.call_args[0][0]
+            assert req.location_uuid == "test-site-uuid"
+            assert req.new_location_name == "Updated Site"
+            # 3.0 kW -> 3000 Watts
+            assert req.new_effective_capacity_watts == 3000
+
+
+@pytest.mark.asyncio
+async def test_update_dataplatform_location_grpc_failure_reports_to_sentry():
+    """If the gRPC call raises, the error is swallowed and reported to Sentry (not propagated)."""
+    mock_stub = AsyncMock()
+    grpc_error = RuntimeError("Data Platform unavailable")
+    mock_stub.UpdateLocation.side_effect = grpc_error
+    mock_channel = AsyncMock()
+    mock_channel.__aenter__.return_value = mock_channel
+
+    with patch("grpc.aio.insecure_channel", return_value=mock_channel):
+        with patch(
+            "ocf.dp.dp_data.service_pb2_grpc.DataPlatformDataServiceStub", return_value=mock_stub
+        ):
+            with patch.object(sentry_sdk, "capture_exception") as mock_capture:
+                # Should not raise: failures are handled internally.
+                await update_dataplatform_location(
+                    site_uuid="test-site-uuid",
+                    client_site_name="Updated Site",
+                    latitude=51.5,
+                    longitude=-0.1,
+                    capacity_kw=3.0,
+                )
 
                 mock_capture.assert_called_once_with(grpc_error)

--- a/tests/test_dataplatform_client.py
+++ b/tests/test_dataplatform_client.py
@@ -15,6 +15,12 @@ def db_session():
     yield None
 
 
+@pytest.fixture(autouse=True)
+def _stub_dataplatform_client():
+    """Override conftest's global stub — these tests exercise the real client methods."""
+    yield
+
+
 @pytest.fixture()
 def dp_client():
     """A DataPlatformClient with its stub swapped for a mock, bypassing any real channel."""
@@ -114,4 +120,138 @@ async def test_resolve_site_uuid_grpc_failure_reports_to_sentry(dp_client, monke
     res = await dp_client.resolve_site_uuid("pvoutput.org_10020")
 
     assert res is None
+    mock_capture.assert_called_once_with(grpc_error)
+
+
+def _mock_resolved_location(dp_client, location_uuid: str) -> None:
+    """Make dp_client.stub.ListLocations resolve to a single matching location."""
+    mock_location = MagicMock()
+    mock_location.location_uuid = location_uuid
+    mock_resp = MagicMock()
+    mock_resp.locations = [mock_location]
+    dp_client.stub.ListLocations.return_value = mock_resp
+
+
+@pytest.mark.asyncio
+async def test_create_location(dp_client):
+    await dp_client.create_location(
+        site_uuid="test-site-uuid",
+        client_site_name="Test Site!",
+        latitude=51.5,
+        longitude=-0.1,
+        capacity_kw=2.5,
+    )
+
+    assert dp_client.stub.CreateLocation.called
+    req = dp_client.stub.CreateLocation.call_args[0][0]
+    # Sanitized: lowercased, non-alphanumeric/underscore/pipe chars replaced with "_".
+    assert req.location_name == "test_site_"
+    assert req.metadata["client_location_name"] == "Test Site!"
+    assert req.geometry_wkt == "POINT(-0.1 51.5)"
+    # 2.5 kW -> 2500 Watts
+    assert req.effective_capacity_watts == 2500
+
+
+@pytest.mark.asyncio
+async def test_create_location_grpc_failure_reports_to_sentry(dp_client, monkeypatch):
+    """If the gRPC call raises, the error is swallowed and reported to Sentry (not propagated)."""
+    grpc_error = RuntimeError("Data Platform unavailable")
+    dp_client.stub.CreateLocation.side_effect = grpc_error
+
+    mock_capture = MagicMock()
+    monkeypatch.setattr(sentry_sdk, "capture_exception", mock_capture)
+
+    # Should not raise: failures are handled internally.
+    await dp_client.create_location(
+        site_uuid="test-site-uuid",
+        client_site_name="Test Site",
+        latitude=51.5,
+        longitude=-0.1,
+        capacity_kw=2.5,
+    )
+
+    mock_capture.assert_called_once_with(grpc_error)
+
+
+@pytest.mark.asyncio
+async def test_update_location(dp_client):
+    """No rename: current and new names match, resolution and update both use it."""
+    _mock_resolved_location(dp_client, "resolved-dp-uuid")
+
+    await dp_client.update_location(
+        site_uuid="test-site-uuid",
+        current_client_site_name="Updated Site!",
+        new_client_site_name="Updated Site!",
+        capacity_kw=3.0,
+    )
+
+    resolve_filter = set(dp_client.stub.ListLocations.call_args[0][0].location_names_filter)
+    assert resolve_filter == {"Updated Site!", "updated_site_"}
+
+    assert dp_client.stub.UpdateLocation.called
+    req = dp_client.stub.UpdateLocation.call_args[0][0]
+    assert req.location_uuid == "resolved-dp-uuid"
+    assert req.new_location_name == "updated_site_"
+    assert req.new_metadata["client_location_name"] == "Updated Site!"
+    # 3.0 kW -> 3000 Watts
+    assert req.new_effective_capacity_watts == 3000
+
+
+@pytest.mark.asyncio
+async def test_update_location_rename(dp_client):
+    """Renaming: the existing location must be resolved by its *current* name, not the new one."""
+    _mock_resolved_location(dp_client, "resolved-dp-uuid")
+
+    await dp_client.update_location(
+        site_uuid="test-site-uuid",
+        current_client_site_name="Old Name",
+        new_client_site_name="New Name",
+        capacity_kw=3.0,
+    )
+
+    resolve_filter = set(dp_client.stub.ListLocations.call_args[0][0].location_names_filter)
+    assert resolve_filter == {"Old Name", "old_name"}
+
+    req = dp_client.stub.UpdateLocation.call_args[0][0]
+    assert req.location_uuid == "resolved-dp-uuid"
+    assert req.new_location_name == "new_name"
+    assert req.new_metadata["client_location_name"] == "New Name"
+
+
+@pytest.mark.asyncio
+async def test_update_location_unresolved_uuid(dp_client):
+    """If the Data Platform location can't be resolved, we skip updating, not update blindly."""
+    mock_resp = MagicMock()
+    mock_resp.locations = []
+    dp_client.stub.ListLocations.return_value = mock_resp
+
+    await dp_client.update_location(
+        site_uuid="test-site-uuid",
+        current_client_site_name="Updated Site",
+        new_client_site_name="Updated Site",
+        capacity_kw=3.0,
+    )
+
+    assert not dp_client.stub.UpdateLocation.called
+
+
+@pytest.mark.asyncio
+async def test_update_location_grpc_failure_reports_to_sentry(dp_client, monkeypatch):
+    """If the gRPC call raises, the error is swallowed and reported to Sentry (not propagated)."""
+    _mock_resolved_location(dp_client, "resolved-dp-uuid")
+
+    grpc_error = RuntimeError("Data Platform unavailable")
+    dp_client.stub.UpdateLocation.side_effect = grpc_error
+
+    mock_capture = MagicMock()
+    monkeypatch.setattr(sentry_sdk, "capture_exception", mock_capture)
+
+    # Should not raise: failures are handled internally.
+    await dp_client.update_location(
+        site_uuid="test-site-uuid",
+        current_client_site_name="Updated Site",
+        new_client_site_name="Updated Site",
+        capacity_kw=3.0,
+    )
+
     mock_capture.assert_called_once_with(grpc_error)

--- a/tests/test_sites.py
+++ b/tests/test_sites.py
@@ -156,3 +156,80 @@ def test_put_site_and_update(db_session, client):
     assert len(sites) == 1
     assert sites[0].orientation == 120
     assert sites[0].tilt == 90
+
+
+def test_post_site_with_dataplatform(db_session, client, monkeypatch):
+    """Test posting a new site when SAVE_TO_DATA_PLATFORM is true."""
+    monkeypatch.setenv("SAVE_TO_DATA_PLATFORM", "true")
+    called_records = []
+
+    async def mock_create(site_uuid, client_site_name, latitude, longitude, capacity_kw):
+        called_records.append((site_uuid, client_site_name, latitude, longitude, capacity_kw))
+
+    monkeypatch.setattr("pv_site_api.main.create_dataplatform_location", mock_create)
+
+    pv_site = PVSiteInputMetadata(
+        client_name="test_client",
+        client_site_id=1,
+        client_site_name="the site name",
+        region="the site's region",
+        dno="the site's dno",
+        gsp="the site's gsp",
+        orientation=180,
+        tilt=90,
+        latitude=50,
+        longitude=0,
+        inverter_capacity_kw=1,
+        module_capacity_kw=1.2,
+        created_utc=datetime.now(timezone.utc).isoformat(),
+    )
+
+    pv_site_dict = json.loads(pv_site.json())
+
+    response = client.post("/sites", json=pv_site_dict)
+    assert response.status_code == 201, response.text
+
+    site_uuid = response.json()["site_uuid"]
+
+    assert len(called_records) == 1
+    assert str(called_records[0][0]) == site_uuid
+    assert called_records[0][1] == "the site name"
+
+
+def test_put_site_with_dataplatform(db_session, client, monkeypatch):
+    """Test updating a site when SAVE_TO_DATA_PLATFORM is true."""
+    pv_site = PVSiteInputMetadata(
+        client_name="test_client",
+        client_site_id=1,
+        client_site_name="the site name",
+        region="the site's region",
+        dno="the site's dno",
+        gsp="the site's gsp",
+        orientation=180,
+        tilt=90,
+        latitude=50,
+        longitude=0,
+        inverter_capacity_kw=1,
+        module_capacity_kw=1.2,
+        created_utc=datetime.now(timezone.utc).isoformat(),
+    )
+
+    pv_site_dict = json.loads(pv_site.model_dump_json())
+
+    response = client.post("sites/", json=pv_site_dict)
+    assert response.status_code == 201, response.text
+    site_uuid = response.json()["site_uuid"]
+
+    monkeypatch.setenv("SAVE_TO_DATA_PLATFORM", "true")
+    called_records = []
+
+    async def mock_update(site_uuid, client_site_name, latitude, longitude, capacity_kw):
+        called_records.append((site_uuid, client_site_name, latitude, longitude, capacity_kw))
+
+    monkeypatch.setattr("pv_site_api.main.update_dataplatform_location", mock_update)
+
+    response = client.put(f"sites/{site_uuid}", json={"orientation": 120})
+    assert response.status_code == 200, response.text
+
+    assert len(called_records) == 1
+    assert str(called_records[0][0]) == site_uuid

--- a/tests/test_sites.py
+++ b/tests/test_sites.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 
 from pvsite_datamodel.sqlmodels import LocationSQL
 
+from pv_site_api.dataplatform_client import DataPlatformClient
 from pv_site_api.pydantic_models import PVSiteInputMetadata, PVSites
 
 
@@ -159,14 +160,13 @@ def test_put_site_and_update(db_session, client):
 
 
 def test_post_site_with_dataplatform(db_session, client, monkeypatch):
-    """Test posting a new site when SAVE_TO_DATA_PLATFORM is true."""
-    monkeypatch.setenv("SAVE_TO_DATA_PLATFORM", "true")
+    """Test posting a new site streams the new location to the Data Platform."""
     called_records = []
 
-    async def mock_create(site_uuid, client_site_name, latitude, longitude, capacity_kw):
+    async def mock_create(self, site_uuid, client_site_name, latitude, longitude, capacity_kw):
         called_records.append((site_uuid, client_site_name, latitude, longitude, capacity_kw))
 
-    monkeypatch.setattr("pv_site_api.main.create_dataplatform_location", mock_create)
+    monkeypatch.setattr(DataPlatformClient, "create_location", mock_create)
 
     pv_site = PVSiteInputMetadata(
         client_name="test_client",
@@ -194,10 +194,12 @@ def test_post_site_with_dataplatform(db_session, client, monkeypatch):
     assert len(called_records) == 1
     assert str(called_records[0][0]) == site_uuid
     assert called_records[0][1] == "the site name"
+    assert called_records[0][2] == 50
+    assert called_records[0][3] == 0
 
 
 def test_put_site_with_dataplatform(db_session, client, monkeypatch):
-    """Test updating a site when SAVE_TO_DATA_PLATFORM is true."""
+    """Test updating a site streams the update to the Data Platform."""
     pv_site = PVSiteInputMetadata(
         client_name="test_client",
         client_site_id=1,
@@ -220,13 +222,16 @@ def test_put_site_with_dataplatform(db_session, client, monkeypatch):
     assert response.status_code == 201, response.text
     site_uuid = response.json()["site_uuid"]
 
-    monkeypatch.setenv("SAVE_TO_DATA_PLATFORM", "true")
     called_records = []
 
-    async def mock_update(site_uuid, client_site_name, latitude, longitude, capacity_kw):
-        called_records.append((site_uuid, client_site_name, latitude, longitude, capacity_kw))
+    async def mock_update(
+        self, site_uuid, current_client_site_name, new_client_site_name, capacity_kw
+    ):
+        called_records.append(
+            (site_uuid, current_client_site_name, new_client_site_name, capacity_kw)
+        )
 
-    monkeypatch.setattr("pv_site_api.main.update_dataplatform_location", mock_update)
+    monkeypatch.setattr(DataPlatformClient, "update_location", mock_update)
 
     response = client.put(f"sites/{site_uuid}", json={"orientation": 120})
     assert response.status_code == 200, response.text


### PR DESCRIPTION
# Pull Request

## Description

Adds create/update location sync to the Data Platform for `POST /sites` and `PUT /sites/{site_uuid}`. This branch (`update_locations`) previously had its own standalone `create_dataplatform_location`/`update_dataplatform_location` functions, written before the already-merged `save_gen_data_to_dp` PR (#226) restructured the Data Platform integration around a single `DataPlatformClient` class injected via FastAPI's dependency system. Merging `main` into this branch replaced that module out from under these call sites, so this PR both re-ports the location sync onto the new `DataPlatformClient` pattern and fixes several real bugs surfaced by testing it end-to-end for the first time.

**Changes include:**

- `pv_site_api/dataplatform_client.py`:
  - Added `create_location()` and `update_location()` methods to `DataPlatformClient`, replacing the old standalone functions.
  - `location_name` is derived from the site's `client_location_name` via a new `_sanitize_location_name()` helper (lowercased, non-alphanumeric/underscore/pipe characters replaced with `_`), since Data Platform enforces a strict charset on that field. The original, unsanitized name is preserved verbatim in the request's `metadata.client_location_name`.
  - Fixed two validation errors surfaced by live testing: `geometry_wkt` is now set (Data Platform requires it for `CreateLocation`), and `associated_latlng` was removed since it's mutually exclusive with `geometry_wkt` for Point geometries — the server derives lat/lng from the WKT point.
  - Fixed a design bug in `update_location`: Data Platform assigns its own `location_uuid` at creation time, independent of pv-site-api's site UUID, so the location must be resolved by name (via `resolve_site_uuid`) rather than assumed to equal `site_uuid`. It's resolved by the site's *current* name (as still registered on Data Platform), not its new name — otherwise renaming a site silently fails to find the existing location.
- `pv_site_api/main.py`: `post_site_info`/`put_site_info` now depend on `DataPlatformClient` via `Depends(get_dataplatform_client)` and are `async def`. `put_site_info` fetches the site's current name before calling `edit_site()`, so the pre-rename name is available to resolve the existing Data Platform location.
- `tests/conftest.py`: added an autouse fixture stubbing all `DataPlatformClient` methods to no-ops by default, so tests that don't care about Data Platform behavior don't make real network calls; tests that do assert on it override the stub per-test.
- Updated/added unit tests in `tests/test_dataplatform_client.py` and `tests/test_sites.py` covering `create_location`, `update_location` (including the rename and unresolved-location paths), and both endpoints' integration with the new client.

Fixes #

## How Has This Been Tested?

- Verified end-to-end against a live dev server tunnelled to the OCF Data Platform:
  - `POST /sites` with a name containing special characters (`test_pavan-final_test`) — confirmed via `ListLocations` that `location_name` is sanitized (`test_pavan_final_test`) while `metadata.client_location_name` preserves the original name exactly, and `effective_capacity_watts`/`latlng` match the request.
  - `PUT /sites/{site_uuid}` updating `capacity_kw` — confirmed the Data Platform location's `effective_capacity_watts` reflects the new value.
  - `PUT /sites/{site_uuid}` renaming `client_site_name` — confirmed (after the current-name-resolution fix) that the existing Data Platform location is updated in place rather than the rename silently failing.
- Unit tests: `test_create_location`, `test_create_location_grpc_failure_reports_to_sentry`, `test_update_location`, `test_update_location_rename`, `test_update_location_unresolved_uuid`, `test_update_location_grpc_failure_reports_to_sentry`, `test_post_site_with_dataplatform`, `test_put_site_with_dataplatform`.
- Full suite passes locally (`pytest tests/`).

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
